### PR TITLE
OATH2 Username & Pwd access support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,6 @@ app/index-dev.html
 
 #IDE
 .idea
+nbproject
 
 bower_components

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -3,6 +3,7 @@
 // App libraries
 var app = angular.module('oauth', [
   'oauth.directive',      // login directive
+  'oauth.directive.pwd',  // password auth login form directive
   'oauth.accessToken',    // access token service
   'oauth.endpoint',       // oauth endpoint service
   'oauth.profile',        // profile model

--- a/app/scripts/directives/oauth-pwd.js
+++ b/app/scripts/directives/oauth-pwd.js
@@ -1,0 +1,124 @@
+'use strict';
+
+var directives = angular.module('oauth.directive.pwd', []);
+
+directives.directive('oauthPwd', function(AccessToken, Profile, $rootScope, $compile, $http, $templateCache) {
+
+  var definition = {
+    restrict: 'AE',
+    replace: true,
+    scope: {
+      clientId: '@',      // (required) client id
+      authPath: '@',      // (optional) the path to post to if not /oauth
+      profilePath: '@',   // (optional) user profile path (e.g /users/me)
+      logoutPath: '@',    // (optional) a path to post to so the token is destroyed on the server (e.g /users/me)
+      loginTemplate: '@', // (optional) template to render (e.g views/templates/login-form.html)
+      registerUrl: '@'    // (optional) a link to the registration page is shown when a URL is specified
+    }
+  };
+
+  definition.link = function postLink(scope, element) {
+    scope.show = 'none';
+
+    scope.$watch('clientId', function(value) { init() });
+    
+    element.on('submit', '#loginForm', function() { scope.login() });
+    scope.$on('$destroy', function() { element.off('submit', '#loginForm') });
+
+    scope.$on('oauth:authorized', function(event, token) {
+        console.log('auth:', token);
+    });
+
+    var init = function() {
+      initAttributes();          // sets defaults
+      compile();                 // compiles the desired layout
+      AccessToken.set(scope);    // sets the access token object (if existing, from fragment or session)
+      initProfile(scope);        // gets the profile resource (if existing the access token)
+      updateView();              // sets the view (logged in or out)
+    };
+
+    var initAttributes = function() {
+      scope.authPath      = scope.authPath      || '/oauth';
+      scope.loginTemplate = scope.loginTemplate || 'views/templates/login-form.html';
+      scope.registerUrl   = scope.registerUrl   || undefined;
+      scope.profilePath   = scope.profilePath   || undefined;
+      scope.logoutPath    = scope.logoutPath    || undefined;
+    };
+
+    var compile = function() {
+      $http.get(scope.loginTemplate, { cache: $templateCache }).success(function(html) {
+        element.html(html);
+        $compile(element.contents())(scope);
+      });
+    };
+
+    var initProfile = function(scope) {
+      var token = AccessToken.get();
+
+      if (token && token.access_token && scope.profilePath) {
+        Profile.find(scope.profilePath).success(function(response) {
+          scope.profile = response
+        })
+      }
+    };
+
+    var updateView = function() {
+      var token = AccessToken.get();
+
+      if (!token)             { return loggedOut()  }  // without access token it's logged out
+      if (token.access_token) { return authorized() }  // if there is the access token we are done
+      if (token.error)        { return denied()     }  // if the request has been denied we fire the denied event
+    };
+
+    scope.login = function() {
+      delete scope.errorMsg;
+      $http.post(scope.authPath, {
+        "grant_type": "password",
+        "username": scope.username,
+        "password": scope.password,
+        "client_id": scope.clientId
+      }).then(function(successResponse) {
+        console.log(successResponse);
+        AccessToken.set(scope, successResponse.data);
+        console.log(AccessToken.get());
+        initProfile(scope);
+        updateView();
+      }, function(errorResponse) {
+        scope.errorMsg = (errorResponse.data && errorResponse.data.detail) || 'Invalid credentials';
+      });
+    };
+
+    scope.logout = function() {
+      scope.logoutPath && $http.post(scope.logoutPath, data).success(successCallback);
+      AccessToken.destroy(scope);
+      loggedOut();
+    };
+
+    // user is authorized
+    var authorized = function() {
+        console.log('broadcast auth');
+      $rootScope.$broadcast('oauth:authorized', AccessToken.get());
+      scope.show = 'logged-in';
+    };
+
+    // set the oauth directive to the logged-out status
+    var loggedOut = function() {
+      $rootScope.$broadcast('oauth:logout');
+      scope.show = 'logged-out';
+    };
+
+    // set the oauth directive to the denied status
+    var denied = function() {
+      scope.show = 'denied';
+      $rootScope.$broadcast('oauth:denied');
+    };
+
+    // Updates the template at runtime
+    scope.$on('oauth:template:update', function(event, template) {
+      scope.template = template;
+      compile(scope);
+    });
+  };
+
+  return definition
+});

--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -19,11 +19,13 @@ accessTokenService.factory('AccessToken', function($rootScope, $location, $sessi
 
   /*
    * Sets and returns the access token. It tries (in order) the following strategies:
+   * - checks for token parameters passed to this method
    * - takes the token from the fragment URI
    * - takes the token from the sessionStorage
    */
 
-  service.set = function() {
+  service.set = function(scope, tokenParams) {
+    if (service.setTokenFromParams(tokenParams)) { return token }
     service.setTokenFromString($location.hash());
     service.setTokenFromSession();
     return token
@@ -54,6 +56,17 @@ accessTokenService.factory('AccessToken', function($rootScope, $location, $sessi
    * PRIVATE METHODS *
    * * * * * * * * * */
 
+
+  /*
+   * Set the token directly when parameters are received and return the success status.
+   */
+  
+  service.setTokenFromParams = function(params) {
+    if (params) {
+        service.setToken(params);
+    }
+    return !!params;
+  };
 
   /*
    * Get the access token from a string and save it

--- a/app/views/templates/login-form.html
+++ b/app/views/templates/login-form.html
@@ -1,0 +1,16 @@
+<form role="form" id="loginForm">
+    <alert ng-if="errorMsg" type="danger">{{errorMsg}}</alert>
+    <div class="form-group">
+        <label for="username">Username</label>
+        <input ng-model="username" type="text" class="form-control" id="username">
+    </div>
+    <div class="form-group">
+        <label for="password">Password</label>
+        <input ng-model="password" type="password" class="form-control" id="password">
+    </div>
+    <div><button type="submit" class="btn btn-default">Submit</button></div>
+    <div>
+        <br>
+        <span ng-if="registerUrl">Don't have an account? <a href="{{registerUrl}}">Register here</a></span>
+    </div>
+</form>


### PR DESCRIPTION
I have an application where I want to use OATH2 Username & Pwd access by having a client side login form and posting a JSON object with credentials to the server. The description of the workflow I have at hand can be seen on the [Apigility website](https://apigility.org/documentation/auth/authentication-oauth2#username-and-password-access).

I really like your implementation of the oauth-ng module and thought I'd contribute support for this rather than writing my own module. This branch is not ready for a pull into the master yet, but I wanted to get your feedback on whether you would consider adding this work to the module. At the moment you can use the `<oauth-pwd>` directive (with parameters deduced from the source) to display a login form and once a success result is obtained the `AccessToken` service is set as before and events triggered. 

If you'd be interested in a merge I'll complete the implementation, clean it up and let you know when the branch is ready.