### PR TITLE
Ignore tokens if the state does not match

### DIFF
--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -24,8 +24,8 @@ accessTokenService.factory('AccessToken', function($rootScope, $location, $sessi
      * - takes the token from the fragment URI
      * - takes the token from the sessionStorage
      */
-    service.set = function(){
-        setTokenFromString($location.hash());
+    service.set = function(params){
+        setTokenFromString($location.hash(), params.state);
 
         //If hash is present in URL always use it, cuz its coming from oAuth2 provider redirect
         if(null === service.token){
@@ -62,8 +62,8 @@ accessTokenService.factory('AccessToken', function($rootScope, $location, $sessi
      * Get the access token from a string and save it
      * @param hash
      */
-    var setTokenFromString = function(hash){
-        var params = getTokenFromString(hash);
+    var setTokenFromString = function(hash,state){
+        var params = getTokenFromString(hash,state);
 
         if(params){
             removeFragment();
@@ -104,7 +104,7 @@ accessTokenService.factory('AccessToken', function($rootScope, $location, $sessi
      * @param hash
      * @returns {{}}
      */
-    var getTokenFromString = function(hash){
+    var getTokenFromString = function(hash,state){
         var params = {},
             regex = /([^&=]+)=([^&]*)/g,
             m;
@@ -113,7 +113,7 @@ accessTokenService.factory('AccessToken', function($rootScope, $location, $sessi
             params[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);
         }
 
-        if(params.access_token || params.error){
+        if((params.access_token && params.state === state) || params.error){
             return params;
         }
     };

--- a/test/spec/directives/oauth.js
+++ b/test/spec/directives/oauth.js
@@ -5,7 +5,7 @@ describe('oauth', function() {
   var $rootScope, $location, $sessionStorage, $httpBackend, $compile, AccessToken, Endpoint, element, scope, result, callback;
 
   var uri      = 'http://example.com/oauth/authorize?response_type=token&client_id=client-id&redirect_uri=http://example.com/redirect&scope=scope&state=/';
-  var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path';
+  var fragment = 'access_token=token&token_type=bearer&expires_in=7200';
   var denied   = 'error=access_denied&error_description=error';
   var headers  = { 'Accept': 'application/json, text/plain, */*', 'Authorization': 'Bearer token' }
   var profile  = { id: '1', full_name: 'Alice Wonderland', email: 'alice@example.com' };


### PR DESCRIPTION
In order to protect against cross site request forgery, you should check the state parameter matches the one returned in the fragment.