### PR TITLE
Adds configurable local storage support by switching to the localStorageService

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,9 +24,10 @@ module.exports = function (grunt) {
 
   try {
     var component = require('./bower.json')
-    yeomanConfig.name    = component.name    || 'no-name';
+    yeomanConfig.name = component.name || 'no-name';
     yeomanConfig.version = component.version || '0.0.0.undefined';
-  } catch (e) {}
+  } catch (e) {
+  }
 
 
   // Define the configuration for all the tasks
@@ -123,14 +124,16 @@ module.exports = function (grunt) {
     // Empties folders to start fresh
     clean: {
       dist: {
-        files: [{
-          dot: true,
-          src: [
-            '.tmp',
-            '<%= yeoman.dist %>/*',
-            '!<%= yeoman.dist %>/.git*'
-          ]
-        }]
+        files: [
+          {
+            dot: true,
+            src: [
+              '.tmp',
+              '<%= yeoman.dist %>/*',
+              '!<%= yeoman.dist %>/.git*'
+            ]
+          }
+        ]
       },
       server: '.tmp'
     },
@@ -141,12 +144,14 @@ module.exports = function (grunt) {
         browsers: ['last 1 version']
       },
       dist: {
-        files: [{
-          expand: true,
-          cwd: '.tmp/styles/',
-          src: '{,*/}*.css',
-          dest: '.tmp/styles/'
-        }]
+        files: [
+          {
+            expand: true,
+            cwd: '.tmp/styles/',
+            src: '{,*/}*.css',
+            dest: '.tmp/styles/'
+          }
+        ]
       }
     },
 
@@ -180,27 +185,31 @@ module.exports = function (grunt) {
     // minsafe compatible so Uglify does not destroy the ng references
     ngmin: {
       dist: {
-        files: [{
-          expand: true,
-          cwd: '.tmp/concat/scripts',
-          src: '*.js',
-          dest: '.tmp/concat/scripts'
-        }]
+        files: [
+          {
+            expand: true,
+            cwd: '.tmp/concat/scripts',
+            src: '*.js',
+            dest: '.tmp/concat/scripts'
+          }
+        ]
       }
     },
 
     // Copies remaining files to places other tasks can use
     copy: {
       dist: {
-        files: [{
-          expand: true,
-          dot: true,
-          cwd: '<%= yeoman.app %>',
-          dest: '<%= yeoman.dist %>',
-          src: [
-            'views/{,*/}*.html',
-          ]
-        }]
+        files: [
+          {
+            expand: true,
+            dot: true,
+            cwd: '<%= yeoman.app %>',
+            dest: '<%= yeoman.dist %>',
+            src: [
+              'views/{,*/}*.html'
+            ]
+          }
+        ]
       },
       styles: {
       }
@@ -229,9 +238,17 @@ module.exports = function (grunt) {
 
     // Test settings
     karma: {
+      options: {
+        configFile: 'karma.conf.js'
+      },
       unit: {
-        configFile: 'karma.conf.js',
-        singleRun: false
+        singleRun: true
+      },
+      dev: {
+        singleRun: false,
+        reporters: 'dots',
+        autoWatch: true,
+        browsers: ['Chrome']
       }
     },
 
@@ -242,10 +259,12 @@ module.exports = function (grunt) {
           './': 'dist/**/*.*'
         },
         options: {
-          replacements: [{
-            pattern: /views\/templates\/default\.html/g,
-            replacement: 'bower_components/<%= yeoman.name %>/dist/views/templates/default.html'
-          }]
+          replacements: [
+            {
+              pattern: /views\/templates\/default\.html/g,
+              replacement: 'bower_components/<%= yeoman.name %>/dist/views/templates/default.html'
+            }
+          ]
         }
       }
     }
@@ -278,7 +297,7 @@ module.exports = function (grunt) {
     'concurrent:test',
     'autoprefixer',
     'connect:test',
-    'karma'
+    'karma:unit'
   ]);
 
   grunt.registerTask('build', [
@@ -286,7 +305,7 @@ module.exports = function (grunt) {
     'copy',
     'useminPrepare',
     'concat',
-    'string-replace',
+    'string-replace'
   ]);
 
   grunt.registerTask('default', [

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -6,10 +6,12 @@ var app = angular.module('oauth', [
   'oauth.accessToken',    // access token service
   'oauth.endpoint',       // oauth endpoint service
   'oauth.profile',        // profile model
-  'oauth.interceptor'     // bearer token interceptor
+  'oauth.interceptor',    // bearer token interceptor
+  'LocalStorageModule'
 ]);
 
-angular.module('oauth').config(['$locationProvider','$httpProvider',
-  function($locationProvider, $httpProvider) {
+angular.module('oauth').config(['$locationProvider','$httpProvider','localStorageServiceProvider',
+  function($locationProvider, $httpProvider, localStorageServiceProvider) {
     $httpProvider.interceptors.push('ExpiredInterceptor');
+    localStorageServiceProvider.setStorageType('sessionStorage');
   }]);

--- a/app/scripts/interceptors/oauth-interceptor.js
+++ b/app/scripts/interceptors/oauth-interceptor.js
@@ -2,12 +2,12 @@
 
 var interceptorService = angular.module('oauth.interceptor', []);
 
-interceptorService.factory('ExpiredInterceptor', function ($rootScope, $q, $sessionStorage) {
+interceptorService.factory('ExpiredInterceptor', function ($rootScope, $q, localStorageService) {
 
   var service = {};
 
   service.request = function(config) {
-    var token = $sessionStorage.token;
+    var token = localStorageService.get('token');
 
     if (token && expired(token))
       $rootScope.$broadcast('oauth:expired', token);

--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var accessTokenService = angular.module('oauth.accessToken', ['ngStorage']);
+var accessTokenService = angular.module('oauth.accessToken', ['LocalStorageModule']);
 
-accessTokenService.factory('AccessToken', function($rootScope, $location, $sessionStorage, $timeout){
+accessTokenService.factory('AccessToken', function($rootScope, $location, localStorageService, $timeout){
 
     var service = {
             token: null
@@ -40,7 +40,7 @@ accessTokenService.factory('AccessToken', function($rootScope, $location, $sessi
      * @returns {null}
      */
     service.destroy = function(){
-        delete $sessionStorage.token;
+        localStorageService.remove('token');
         this.token = null;
         return this.token;
     };
@@ -77,8 +77,8 @@ accessTokenService.factory('AccessToken', function($rootScope, $location, $sessi
      * Set the access token from the sessionStorage.
      */
     var setTokenFromSession = function(){
-        if($sessionStorage.token){
-            var params = $sessionStorage.token;
+        if(localStorageService.get('token')){
+            var params = localStorageService.get('token');
             params.expires_at = new Date(params.expires_at);
             setToken(params);
         }
@@ -122,7 +122,7 @@ accessTokenService.factory('AccessToken', function($rootScope, $location, $sessi
      * Save the access token into the session
      */
     var setTokenInSession = function(){
-        $sessionStorage.token = service.token;
+        localStorageService.set('token', service.token);
     };
 
     /**

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "angular": "~1.2.22",
-    "ngstorage": "~0.3.0"
+    "angular-local-storage": "~0.1.3"
   },
   "devDependencies": {
     "json3": "~3.2.4",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,8 +13,9 @@ module.exports = function(config) {
     files: [
       'app/bower_components/jquery/jquery.js',
       'app/bower_components/angular/angular.js',
+      'app/bower_components/angular/angular.js',
+      'app/bower_components/angular-local-storage/dist/angular-local-storage.js',
       'app/bower_components/angular-mocks/angular-mocks.js',
-      'app/bower_components/ngstorage/ngStorage.js',
       'app/bower_components/timecop/timecop-0.1.1.js',
       'app/scripts/*.js',
       'app/scripts/**/*.js',

--- a/test/spec/directives/oauth.js
+++ b/test/spec/directives/oauth.js
@@ -2,7 +2,7 @@
 
 describe('oauth', function() {
 
-  var $rootScope, $location, $sessionStorage, $httpBackend, $compile, AccessToken, Endpoint, element, scope, result, callback;
+  var $rootScope, $location, localStorageService, $httpBackend, $compile, AccessToken, Endpoint, element, scope, result, callback;
 
   var uri      = 'http://example.com/oauth/authorize?response_type=token&client_id=client-id&redirect_uri=http://example.com/redirect&scope=scope&state=/';
   var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path';
@@ -16,7 +16,7 @@ describe('oauth', function() {
   beforeEach(inject(function($injector) { $rootScope      = $injector.get('$rootScope') }));
   beforeEach(inject(function($injector) { $compile        = $injector.get('$compile') }));
   beforeEach(inject(function($injector) { $location       = $injector.get('$location') }));
-  beforeEach(inject(function($injector) { $sessionStorage = $injector.get('$sessionStorage') }));
+  beforeEach(inject(function($injector) { localStorageService = $injector.get('localStorageService') }));
   beforeEach(inject(function($injector) { $httpBackend    = $injector.get('$httpBackend') }));
   beforeEach(inject(function($injector) { AccessToken     = $injector.get('AccessToken') }));
   beforeEach(inject(function($injector) { Endpoint        = $injector.get('Endpoint') }));

--- a/test/spec/services/access-token.js
+++ b/test/spec/services/access-token.js
@@ -2,7 +2,7 @@
 
 describe('AccessToken', function() {
 
-  var result, $location, $sessionStorage, AccessToken, date;
+  var result, $location, localStorageService, AccessToken, date;
 
   var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path&extra=stuff';
   var denied   = 'error=access_denied&error_description=error';
@@ -12,7 +12,7 @@ describe('AccessToken', function() {
   beforeEach(module('oauth'));
 
   beforeEach(inject(function($injector) { $location       = $injector.get('$location') }));
-  beforeEach(inject(function($injector) { $sessionStorage = $injector.get('$sessionStorage') }));
+  beforeEach(inject(function($injector) { localStorageService = $injector.get('localStorageService') }));
   beforeEach(inject(function($injector) { AccessToken     = $injector.get('AccessToken') }));
 
 
@@ -58,7 +58,7 @@ describe('AccessToken', function() {
       });
 
       it('stores the token in the session', function() {
-        var stored_token = $sessionStorage.token;
+        var stored_token = localStorageService.get('token');
         expect(result.access_token).toEqual('token');
       });
     });
@@ -66,7 +66,7 @@ describe('AccessToken', function() {
     describe('with the access token stored in the session', function() {
 
       beforeEach(function() {
-        $sessionStorage.token = token;
+        localStorageService.set('token',token);
       });
 
       beforeEach(function() {
@@ -97,7 +97,7 @@ describe('AccessToken', function() {
       });
 
       it('stores the error message in the session', function() {
-        var stored_token = $sessionStorage.token;
+        var stored_token = localStorageService.get('token');
         expect(result.error).toBe('access_denied');
       });
     });
@@ -143,7 +143,7 @@ describe('AccessToken', function() {
     });
 
     it('reset the cache', function() {
-      expect($sessionStorage.token).toBeUndefined;
+      expect(localStorageService.get('token')).toBeUndefined;
     });
   });
 
@@ -202,7 +202,7 @@ describe('AccessToken', function() {
                 //It is an invalid test to have oAuth hash AND be getting token from session
                 //if hash is in URL it should always be used, cuz its coming from oAuth2 provider re-direct
                 $location.hash('');
-                $sessionStorage.token = token;
+                localStorageService.set('token', token);
                 result = AccessToken.set().expires_at;
             });
 

--- a/test/spec/services/endpoint.js
+++ b/test/spec/services/endpoint.js
@@ -2,7 +2,7 @@
 
 describe('Endpoint', function() {
 
-  var result, $location, $sessionStorage, Endpoint;
+  var result, $location, localStorageService, Endpoint;
 
   var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path';
   var params   = { site: 'http://example.com', clientId: 'client-id', redirectUri: 'http://example.com/redirect', scope: 'scope', authorizePath: '/oauth/authorize' };
@@ -11,7 +11,7 @@ describe('Endpoint', function() {
   beforeEach(module('oauth'));
 
   beforeEach(inject(function($injector) { $location       = $injector.get('$location') }));
-  beforeEach(inject(function($injector) { $sessionStorage = $injector.get('$sessionStorage') }));
+  beforeEach(inject(function($injector) { localStorageService = $injector.get('localStorageService') }));
   beforeEach(inject(function($injector) { Endpoint        = $injector.get('Endpoint') }));
 
   describe('#set', function() {


### PR DESCRIPTION
Suggest that instead of ngStorage you use angular-local-storage.  It's a more configurable agnostic way of using the various methods of doing storage.  It allows the user of your module to configure their storage engine however they choose including cookie storage if they so choose.