### PR TITLE
Storage - session storage or local storage

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -17,6 +17,7 @@
     <!-- build:css({.tmp,app}) styles/main.css -->
     <link rel="stylesheet" href="styles/main.css">
     <!-- endbuild -->
+    <base href="/">
   </head>
   <body ng-app="app">
 
@@ -32,7 +33,8 @@
     client-id="CLIENT_ID_HERE"
     redirect-uri="REDIRECT_URI_HERE"
     profile-uri="PROFILE_URI_HERE"
-    scope="SCOPE_HERE">
+    scope="SCOPE_HERE"
+    storage="STORAGE_TYPE_HERE">
     </oauth>
     </div>
 
@@ -46,6 +48,7 @@
     <script src="scripts/services/access-token.js"></script>
     <script src="scripts/services/endpoint.js"></script>
     <script src="scripts/services/profile.js"></script>
+    <script src="scripts/services/storage.js"></script>
     <script src="scripts/interceptors/oauth-interceptor.js"></script>
     <script src="scripts/directives/oauth.js"></script>
     <!-- endbuild -->

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -6,7 +6,8 @@ var app = angular.module('oauth', [
   'oauth.accessToken',    // access token service
   'oauth.endpoint',       // oauth endpoint service
   'oauth.profile',        // profile model
-  'oauth.interceptor'     // bearer token interceptor
+  'oauth.interceptor',    // bearer token interceptor
+  'oauth.storage'         // storage
 ]);
 
 angular.module('oauth').config(['$locationProvider','$httpProvider',

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -6,8 +6,8 @@ var app = angular.module('oauth', [
   'oauth.accessToken',    // access token service
   'oauth.endpoint',       // oauth endpoint service
   'oauth.profile',        // profile model
-  'oauth.interceptor',    // bearer token interceptor
-  'oauth.storage'         // storage
+  'oauth.storage',        // storage
+  'oauth.interceptor'     // bearer token interceptor
 ]);
 
 angular.module('oauth').config(['$locationProvider','$httpProvider',

--- a/app/scripts/directives/oauth.js
+++ b/app/scripts/directives/oauth.js
@@ -6,12 +6,13 @@ directives.directive('oauth', [
   'AccessToken',
   'Endpoint',
   'Profile',
+  'Storage',
   '$location',
   '$rootScope',
   '$compile',
   '$http',
   '$templateCache',
-  function(AccessToken, Endpoint, Profile, $location, $rootScope, $compile, $http, $templateCache) {
+  function(AccessToken, Endpoint, Profile, Storage, $location, $rootScope, $compile, $http, $templateCache) {
 
   var definition = {
     restrict: 'AE',
@@ -26,7 +27,8 @@ directives.directive('oauth', [
       template: '@',      // (optional) template to render (e.g views/templates/default.html)
       text: '@',          // (optional) login text
       authorizePath: '@', // (optional) authorization url
-      state: '@'          // (optional) An arbitrary unique string created by your app to guard against Cross-site Request Forgery
+      state: '@',         // (optional) An arbitrary unique string created by your app to guard against Cross-site Request Forgery
+      storage: '@'        // (optional) Store token in 'sessionStorage' or 'localStorage', defaults to 'sessionStorage'
     }
   };
 
@@ -37,6 +39,7 @@ directives.directive('oauth', [
 
     var init = function() {
       initAttributes();          // sets defaults
+      Storage.use(scope.storage);// set storage
       compile();                 // compiles the desired layout
       Endpoint.set(scope);       // sets the oauth authorization url
       AccessToken.set(scope);    // sets the access token object (if existing, from fragment or session)
@@ -52,6 +55,7 @@ directives.directive('oauth', [
       scope.text          = scope.text          || 'Sign In';
       scope.state         = scope.state         || undefined;
       scope.scope         = scope.scope         || undefined;
+      scope.storage       = scope.storage       || 'sessionStorage';
     };
 
     var compile = function() {

--- a/app/scripts/interceptors/oauth-interceptor.js
+++ b/app/scripts/interceptors/oauth-interceptor.js
@@ -2,12 +2,12 @@
 
 var interceptorService = angular.module('oauth.interceptor', []);
 
-interceptorService.factory('ExpiredInterceptor', ['$rootScope', '$q', '$sessionStorage', function ($rootScope, $q, $sessionStorage) {
+interceptorService.factory('ExpiredInterceptor', ['Storage', '$rootScope', '$q', function (Storage, $rootScope, $q) {
 
   var service = {};
 
   service.request = function(config) {
-    var token = $sessionStorage.token;
+    var token = Storage.get('token');
 
     if (token && expired(token))
       $rootScope.$broadcast('oauth:expired', token);

--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var accessTokenService = angular.module('oauth.accessToken', ['ngStorage']);
+var accessTokenService = angular.module('oauth.accessToken', []);
 
-accessTokenService.factory('AccessToken', ['$rootScope', '$location', '$sessionStorage', '$interval', function($rootScope, $location, $sessionStorage, $interval){
+accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location', '$interval', function(Storage, $rootScope, $location, $interval){
 
     var service = {
             token: null
@@ -40,7 +40,7 @@ accessTokenService.factory('AccessToken', ['$rootScope', '$location', '$sessionS
      * @returns {null}
      */
     service.destroy = function(){
-        delete $sessionStorage.token;
+        Storage.delete('token');
         this.token = null;
         return this.token;
     };
@@ -78,8 +78,8 @@ accessTokenService.factory('AccessToken', ['$rootScope', '$location', '$sessionS
      * Set the access token from the sessionStorage.
      */
     var setTokenFromSession = function(){
-        if($sessionStorage.token){
-            var params = $sessionStorage.token;
+        if(Storage.get('token')){
+            var params = Storage.get('token');
             params.expires_at = new Date(params.expires_at);
             setToken(params);
         }
@@ -123,7 +123,7 @@ accessTokenService.factory('AccessToken', ['$rootScope', '$location', '$sessionS
      * Save the access token into the session
      */
     var setTokenInSession = function(){
-        $sessionStorage.token = service.token;
+        Storage.set('token', service.token);
     };
 
     /**

--- a/app/scripts/services/storage.js
+++ b/app/scripts/services/storage.js
@@ -2,7 +2,7 @@
 
 var storageService = angular.module('oauth.storage', ['ngStorage']);
 
-storageService.factory('Storage', function($rootScope, $sessionStorage, $localStorage){
+storageService.factory('Storage', ['$rootScope', '$sessionStorage', '$localStorage', function($rootScope, $sessionStorage, $localStorage){
 
     var service = {
         storage: $sessionStorage // By default
@@ -46,4 +46,4 @@ storageService.factory('Storage', function($rootScope, $sessionStorage, $localSt
     };
 
     return service;
-});
+}]);

--- a/app/scripts/services/storage.js
+++ b/app/scripts/services/storage.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var storageService = angular.module('oauth.storage', ['ngStorage']);
+
+storageService.factory('Storage', function($rootScope, $sessionStorage, $localStorage){
+
+    var service = {
+        storage: $sessionStorage // By default
+    };
+
+    /**
+     * Deletes the item from storage,
+     * Returns the item's previous value
+     */
+    service.delete = function (name) {
+        var stored = this.get(name);
+        delete this.storage[name];
+        return stored;
+    };
+
+    /**
+     * Returns the item from storage
+     */
+    service.get = function (name) {
+        return this.storage[name];
+    };
+
+    /**
+     * Sets the item in storage to the value specified
+     * Returns the item's value
+     */
+    service.set = function (name, value) {
+        this.storage[name] = value;
+        return this.get(name);
+    };
+
+    /**
+     * Change the storage service being used
+     */
+    service.use = function (storage) {
+        if (storage === 'sessionStorage') {
+            this.storage = $sessionStorage;
+        } else if (storage === 'localStorage') {
+            this.storage = $localStorage;
+        }
+    };
+
+    return service;
+});

--- a/test/spec/directives/oauth.js
+++ b/test/spec/directives/oauth.js
@@ -2,7 +2,7 @@
 
 describe('oauth', function() {
 
-  var $rootScope, $location, $sessionStorage, $httpBackend, $compile, AccessToken, Endpoint, element, scope, result, callback;
+  var $rootScope, $location, Storage, $httpBackend, $compile, AccessToken, Endpoint, element, scope, result, callback;
 
   var uri      = 'http://example.com/oauth/authorize?response_type=token&client_id=client-id&redirect_uri=http://example.com/redirect&scope=scope&state=/';
   var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path';
@@ -16,7 +16,7 @@ describe('oauth', function() {
   beforeEach(inject(function($injector) { $rootScope      = $injector.get('$rootScope') }));
   beforeEach(inject(function($injector) { $compile        = $injector.get('$compile') }));
   beforeEach(inject(function($injector) { $location       = $injector.get('$location') }));
-  beforeEach(inject(function($injector) { $sessionStorage = $injector.get('$sessionStorage') }));
+  beforeEach(inject(function($injector) { Storage         = $injector.get('Storage') }));
   beforeEach(inject(function($injector) { $httpBackend    = $injector.get('$httpBackend') }));
   beforeEach(inject(function($injector) { AccessToken     = $injector.get('AccessToken') }));
   beforeEach(inject(function($injector) { Endpoint        = $injector.get('Endpoint') }));

--- a/test/spec/services/access-token.js
+++ b/test/spec/services/access-token.js
@@ -2,7 +2,7 @@
 
 describe('AccessToken', function() {
 
-  var result, $location, $sessionStorage, AccessToken, date;
+  var result, $location, Storage, AccessToken, date;
 
   var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path&extra=stuff';
   var denied   = 'error=access_denied&error_description=error';
@@ -12,7 +12,7 @@ describe('AccessToken', function() {
   beforeEach(module('oauth'));
 
   beforeEach(inject(function($injector) { $location       = $injector.get('$location') }));
-  beforeEach(inject(function($injector) { $sessionStorage = $injector.get('$sessionStorage') }));
+  beforeEach(inject(function($injector) { Storage         = $injector.get('Storage') }));
   beforeEach(inject(function($injector) { AccessToken     = $injector.get('AccessToken') }));
 
 
@@ -58,7 +58,7 @@ describe('AccessToken', function() {
       });
 
       it('stores the token in the session', function() {
-        var stored_token = $sessionStorage.token;
+        var stored_token = Storage.get('token');
         expect(result.access_token).toEqual('token');
       });
     });
@@ -66,7 +66,7 @@ describe('AccessToken', function() {
     describe('with the access token stored in the session', function() {
 
       beforeEach(function() {
-        $sessionStorage.token = token;
+        Storage.set('token', token);
       });
 
       beforeEach(function() {
@@ -97,7 +97,7 @@ describe('AccessToken', function() {
       });
 
       it('stores the error message in the session', function() {
-        var stored_token = $sessionStorage.token;
+        var stored_token = Storage.get('token');
         expect(result.error).toBe('access_denied');
       });
     });
@@ -143,7 +143,7 @@ describe('AccessToken', function() {
     });
 
     it('reset the cache', function() {
-      expect($sessionStorage.token).toBeUndefined;
+      expect(Storage.get('token')).toBeUndefined;
     });
   });
 
@@ -202,7 +202,7 @@ describe('AccessToken', function() {
                 //It is an invalid test to have oAuth hash AND be getting token from session
                 //if hash is in URL it should always be used, cuz its coming from oAuth2 provider re-direct
                 $location.hash('');
-                $sessionStorage.token = token;
+                Storage.set('token', token);
                 result = AccessToken.set().expires_at;
             });
 

--- a/test/spec/services/endpoint.js
+++ b/test/spec/services/endpoint.js
@@ -2,7 +2,7 @@
 
 describe('Endpoint', function() {
 
-  var result, $location, $sessionStorage, Endpoint;
+  var result, $location, Storage, Endpoint;
 
   var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path';
   var params   = { site: 'http://example.com', clientId: 'client-id', redirectUri: 'http://example.com/redirect', scope: 'scope', authorizePath: '/oauth/authorize', responseType: 'token' };
@@ -11,7 +11,7 @@ describe('Endpoint', function() {
   beforeEach(module('oauth'));
 
   beforeEach(inject(function($injector) { $location       = $injector.get('$location') }));
-  beforeEach(inject(function($injector) { $sessionStorage = $injector.get('$sessionStorage') }));
+  beforeEach(inject(function($injector) { Storage         = $injector.get('Storage') }));
   beforeEach(inject(function($injector) { Endpoint        = $injector.get('Endpoint') }));
 
   describe('#set', function() {

--- a/test/spec/services/storage.js
+++ b/test/spec/services/storage.js
@@ -1,0 +1,103 @@
+'use strict';
+
+describe('Storage', function() {
+
+  var $sessionStorage, $localStorage, Storage;
+  var token    = 'MOCK TOKEN';
+
+  beforeEach(module('oauth'));
+
+  beforeEach(inject(function($injector) { $sessionStorage = $injector.get('$sessionStorage') }));
+  beforeEach(inject(function($injector) { $localStorage   = $injector.get('$localStorage') }));
+  beforeEach(inject(function($injector) { Storage         = $injector.get('Storage') }));
+
+  it('should use sessionStorage by default', function () {
+    expect(Storage.storage).toEqual($sessionStorage);
+  });
+
+  describe('#use', function () {
+
+    beforeEach(function () {
+      $sessionStorage.$reset();
+      $localStorage.$reset();
+      Storage.storage = null;
+    });
+
+    it('should use sessionStorage when specified', function () {
+      Storage.use('sessionStorage');
+      expect(Storage.storage).toEqual($sessionStorage);
+    });
+
+    it('should use localStorage when specified', function () {
+      Storage.use('localStorage');
+      expect(Storage.storage).toEqual($localStorage);
+    });
+
+  });
+
+  describe('#set', function() {
+
+    beforeEach(function () {
+      $sessionStorage.$reset();
+      $localStorage.$reset();
+    });
+
+    it('should set something in sessionStorage', function () {
+      Storage.storage = $sessionStorage;
+      Storage.set('token', token);
+      expect($sessionStorage.token).toEqual(token);
+    });
+
+    it('should set something in sessionStorage', function () {
+      Storage.storage = $localStorage;
+      Storage.set('token', token);
+      expect($localStorage.token).toEqual(token);
+    });
+
+  });
+
+  describe('#get', function() {
+
+    beforeEach(function () {
+      $sessionStorage.$reset();
+      $localStorage.$reset();
+    });
+
+    it('should set something in sessionStorage', function () {
+      $sessionStorage.token = token
+      Storage.storage = $sessionStorage;
+      expect(Storage.get('token')).toEqual(token);
+    });
+
+    it('should set something in sessionStorage', function () {
+      $localStorage.token = token
+      Storage.storage = $localStorage;
+      expect(Storage.get('token')).toEqual(token);
+    });
+
+  });
+
+  describe('#delete', function() {
+
+    beforeEach(function () {
+      $sessionStorage.$reset();
+      $localStorage.$reset();
+    });
+
+    it('should delete the token from the sessionStorage', function () {
+      $sessionStorage.token = token;
+      Storage.storage = $sessionStorage;
+      expect(Storage.delete('token')).toEqual(token);
+      expect($sessionStorage.token).not.toBeDefined();
+    });
+
+    it('should delete the token from the sessionStorage', function () {
+      $localStorage.token = token;
+      Storage.storage = $localStorage;
+      expect(Storage.delete('token')).toEqual(token);
+      expect($localStorage.token).not.toBeDefined();
+    });
+
+  });
+
+});


### PR DESCRIPTION
Storage service created to allow users to choose between `sessionStorage` (default) or `localStorage`. Simplest way was a wrapper around `$sessionStorage`/`$localStorage`.

Can be configured in the `storage` attribute on the element. I've updated the docs/`gh-pages` branch as well.