### PR TITLE
Supports expires_in property in token being optional

### DIFF
--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -65,6 +65,9 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
             removeFragment();
             setToken(params);
             setExpiresAt();
+            // We have to save it again to make sure expires_at is set
+            //  and the expiry event is set up properly
+            setToken(this.token);
             $rootScope.$broadcast('oauth:login', service.token);
         }
     };
@@ -78,9 +81,8 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
      * Set the access token from the sessionStorage.
      */
     var setTokenFromSession = function(){
-        if(Storage.get('token')){
-            var params = Storage.get('token');
-            params.expires_at = new Date(params.expires_at);
+        var params = Storage.get('token');
+        if (params) {
             setToken(params);
         }
     };
@@ -130,10 +132,15 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
      * Set the access token expiration date (useful for refresh logics)
      */
     var setExpiresAt = function(){
-        if(service.token){
+        if (!service.token) {
+            return;
+        }
+        if(typeof(service.token.expires_in) !== 'undefined' && service.token.expires_in !== null) {
             var expires_at = new Date();
             expires_at.setSeconds(expires_at.getSeconds()+parseInt(service.token.expires_in)-60); // 60 seconds less to secure browser and response latency
             service.token.expires_at = expires_at;
+        } else {
+            service.token.expires_at = null;
         }
     };
 
@@ -142,6 +149,10 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
      * Set the timeout at which the expired event is fired
      */
     var setExpiresAtEvent = function(){
+        // Don't bother if there's no expires token
+        if (typeof(service.token.expires_at) === 'undefined' || service.token.expires_at === null) {
+            return;
+        }
         var time = (new Date(service.token.expires_at))-(new Date());
         if(time){
             $interval(function(){

--- a/test/spec/services/access-token.js
+++ b/test/spec/services/access-token.js
@@ -5,6 +5,8 @@ describe('AccessToken', function() {
   var result, $location, Storage, AccessToken, date;
 
   var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path&extra=stuff';
+  var fragmentForever = 'access_token=token&token_type=bearer&state=/path&extra=stuff';
+  var fragmentImmediate = 'access_token=token&token_type=bearer&expires_in=0&state=/path&extra=stuff';
   var denied   = 'error=access_denied&error_description=error';
   var expires_at = '2014-08-17T17:38:37.584Z';
   var token    = { access_token: 'token', token_type: 'bearer', expires_in: 7200, state: '/path', expires_at: expires_at };
@@ -35,6 +37,38 @@ describe('AccessToken', function() {
       it('sets #expires_at', function() {
         var expected_date = new Date();
         expected_date.setSeconds(expected_date.getSeconds() + 7200 - 60);
+        expect(parseInt(result.expires_at/100)).toBe(parseInt(expected_date/100)); // 10 ms
+      });
+    });
+
+    describe('when sets the access token without an expiry', function() {
+
+      beforeEach(function() {
+        $location.hash(fragmentForever);
+      });
+
+      beforeEach(function() {
+        result = AccessToken.set();
+      });
+
+      it('sets #expires_at', function() {
+        expect(result.expires_at).toBe(null);
+      });
+    });
+
+    describe('when sets the access token with an expiry of 0 (immediate)', function() {
+
+      beforeEach(function() {
+        $location.hash(fragmentImmediate);
+      });
+
+      beforeEach(function() {
+        result = AccessToken.set();
+      });
+
+      it('sets #expires_at', function() {
+        var expected_date = new Date();
+        expected_date.setSeconds(expected_date.getSeconds() - 60);
         expect(parseInt(result.expires_at/100)).toBe(parseInt(expected_date/100)); // 10 ms
       });
     });
@@ -207,7 +241,7 @@ describe('AccessToken', function() {
             });
 
             it('rehydrates the expires_at value', function() {
-                expect(result).toEqual(new Date(expires_at));
+                expect(result).toEqual(expires_at);
             });
         });
     });


### PR DESCRIPTION
Supports expires_in property in token being optional. Previously if expires_in was not present token was automatically expired. Ref issue #70

* If `expires_in` is `0` in the querystring it expires the token immediately
* If `expires_in` is not in the querystring it assumes that the token does not expire and therefore explicitly sets the `expires_at` property to `null`

This does not address the issue that @elwin1234 raised in #70, and I'm still not sure if this is something that you (@andreareginato, @m00s, project owners) want to incorporate, but I thought I'd open the pull request anyways.