### PR TITLE
URI encoding of scopes, request type, and adding nonce

### DIFF
--- a/app/scripts/services/endpoint.js
+++ b/app/scripts/services/endpoint.js
@@ -34,6 +34,10 @@ endpointClient.factory('Endpoint', function() {
           'redirect_uri=' + encodeURIComponent(params.redirectUri) + '&' +
           'scope=' + oAuthScope + '&' +
           'state=' + state;
+
+    if( params.nonce ) {
+      url = url + "&nonce=" + params.nonce;
+    }
     return url;
   };
 

--- a/app/scripts/services/endpoint.js
+++ b/app/scripts/services/endpoint.js
@@ -45,8 +45,8 @@ endpointClient.factory('Endpoint', function() {
    * Redirects the app to the authorization URL
    */
 
-  service.redirect = function() {
-    var targetLocation = this.get();
+  service.redirect = function( overrides ) {
+    var targetLocation = this.get( overrides );
     window.location.replace(targetLocation);
   };
 

--- a/app/scripts/services/endpoint.js
+++ b/app/scripts/services/endpoint.js
@@ -24,11 +24,12 @@ endpointClient.factory('Endpoint', function() {
     var oAuthScope = (params.scope) ? encodeURIComponent(params.scope) : '',
         state = (params.state) ? encodeURIComponent(params.state) : '',
         authPathHasQuery = (params.authorizePath.indexOf('?') == -1) ? false : true,
-        appendChar = (authPathHasQuery) ? '&' : '?';    //if authorizePath has ? already append OAuth2 params
+        appendChar = (authPathHasQuery) ? '&' : '?',    //if authorizePath has ? already append OAuth2 params
+        responseType = (params.responseType) ? encodeURIComponent(params.responseType) : '';
 
     var url = params.site +
           params.authorizePath +
-          appendChar + 'response_type=' + params.responseType + '&' +
+          appendChar + 'response_type=' + responseType + '&' +
           'client_id=' + encodeURIComponent(params.clientId) + '&' +
           'redirect_uri=' + encodeURIComponent(params.redirectUri) + '&' +
           'scope=' + oAuthScope + '&' +

--- a/app/scripts/services/endpoint.js
+++ b/app/scripts/services/endpoint.js
@@ -5,45 +5,44 @@ var endpointClient = angular.module('oauth.endpoint', []);
 endpointClient.factory('Endpoint', function() {
 
   var service = {};
-  var url;
-
 
   /*
    * Defines the authorization URL
    */
 
-  service.set = function(params) {
-    var oAuthScope = (params.scope) ? params.scope : '',
-        state = (params.state) ? encodeURIComponent(params.state) : '',
-        authPathHasQuery = (params.authorizePath.indexOf('?') == -1) ? false : true,
-        appendChar = (authPathHasQuery) ? '&' : '?';    //if authorizePath has ? already append OAuth2 params
-
-    url = params.site +
-          params.authorizePath +
-          appendChar + 'response_type=' + params.responseType + '&' +
-          'client_id=' + encodeURIComponent(params.clientId) + '&' +
-          'redirect_uri=' + encodeURIComponent(params.redirectUri) + '&' +
-          'scope=' + oAuthScope + '&' +
-          'state=' + state;
-
-    return url;
+  service.set = function(configuration) {
+    this.config = configuration;
+    return this.get();
   };
 
   /*
    * Returns the authorization URL
    */
 
-  service.get = function() {
+  service.get = function( overrides ) {
+    var params = angular.extend( {}, service.config, overrides);
+    var oAuthScope = (params.scope) ? params.scope : '',
+        state = (params.state) ? encodeURIComponent(params.state) : '',
+        authPathHasQuery = (params.authorizePath.indexOf('?') == -1) ? false : true,
+        appendChar = (authPathHasQuery) ? '&' : '?';    //if authorizePath has ? already append OAuth2 params
+
+    var url = params.site +
+          params.authorizePath +
+          appendChar + 'response_type=' + params.responseType + '&' +
+          'client_id=' + encodeURIComponent(params.clientId) + '&' +
+          'redirect_uri=' + encodeURIComponent(params.redirectUri) + '&' +
+          'scope=' + oAuthScope + '&' +
+          'state=' + state;
     return url;
   };
-
 
   /*
    * Redirects the app to the authorization URL
    */
 
   service.redirect = function() {
-    window.location.replace(url);
+    var targetLocation = this.get();
+    window.location.replace(targetLocation);
   };
 
   return service;

--- a/app/scripts/services/endpoint.js
+++ b/app/scripts/services/endpoint.js
@@ -21,7 +21,7 @@ endpointClient.factory('Endpoint', function() {
 
   service.get = function( overrides ) {
     var params = angular.extend( {}, service.config, overrides);
-    var oAuthScope = (params.scope) ? params.scope : '',
+    var oAuthScope = (params.scope) ? encodeURIComponent(params.scope) : '',
         state = (params.state) ? encodeURIComponent(params.state) : '',
         authPathHasQuery = (params.authorizePath.indexOf('?') == -1) ? false : true,
         appendChar = (authPathHasQuery) ? '&' : '?';    //if authorizePath has ? already append OAuth2 params

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -1,4 +1,4 @@
-/* oauth-ng - v0.3.8 - 2015-04-20 */
+/* oauth-ng - v0.3.10 - 2015-05-19 */
 
 'use strict';
 
@@ -193,45 +193,49 @@ var endpointClient = angular.module('oauth.endpoint', []);
 endpointClient.factory('Endpoint', function() {
 
   var service = {};
-  var url;
-
 
   /*
    * Defines the authorization URL
    */
 
-  service.set = function(params) {
-    var oAuthScope = (params.scope) ? params.scope : '',
-        state = (params.state) ? encodeURIComponent(params.state) : '',
-        authPathHasQuery = (params.authorizePath.indexOf('?') == -1) ? false : true,
-        appendChar = (authPathHasQuery) ? '&' : '?';    //if authorizePath has ? already append OAuth2 params
-
-    url = params.site +
-          params.authorizePath +
-          appendChar + 'response_type=' + params.responseType + '&' +
-          'client_id=' + encodeURIComponent(params.clientId) + '&' +
-          'redirect_uri=' + encodeURIComponent(params.redirectUri) + '&' +
-          'scope=' + oAuthScope + '&' +
-          'state=' + state;
-
-    return url;
+  service.set = function(configuration) {
+    this.config = configuration;
+    return this.get();
   };
 
   /*
    * Returns the authorization URL
    */
 
-  service.get = function() {
+  service.get = function( overrides ) {
+    var params = angular.extend( {}, service.config, overrides);
+    var oAuthScope = (params.scope) ? encodeURIComponent(params.scope) : '',
+        state = (params.state) ? encodeURIComponent(params.state) : '',
+        authPathHasQuery = (params.authorizePath.indexOf('?') == -1) ? false : true,
+        appendChar = (authPathHasQuery) ? '&' : '?',    //if authorizePath has ? already append OAuth2 params
+        responseType = (params.responseType) ? encodeURIComponent(params.responseType) : '';
+
+    var url = params.site +
+          params.authorizePath +
+          appendChar + 'response_type=' + responseType + '&' +
+          'client_id=' + encodeURIComponent(params.clientId) + '&' +
+          'redirect_uri=' + encodeURIComponent(params.redirectUri) + '&' +
+          'scope=' + oAuthScope + '&' +
+          'state=' + state;
+
+    if( params.nonce ) {
+      url = url + "&nonce=" + params.nonce;
+    }
     return url;
   };
-
 
   /*
    * Redirects the app to the authorization URL
    */
 
-  service.redirect = function() {
-    window.location.replace(url);
+  service.redirect = function( overrides ) {
+    var targetLocation = this.get( overrides );
+    window.location.replace(targetLocation);
   };
 
   return service;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "postinstall": "bower install --allow-root",
+    "postinstall": "bower install",
     "clean": "rm -rf node_modules dist app/bower_components",
     "test": "grunt test && grunt build"
   }

--- a/test/spec/services/endpoint.js
+++ b/test/spec/services/endpoint.js
@@ -175,5 +175,14 @@ describe('Endpoint', function() {
         expect( result ).toEqual( expectedUri );
       });
     });
+
+    describe( "on repsonse type with spaces", function(){
+      it( "correctly encodes the spaces", function(){
+        var override    = { responseType: 'id_token token' };
+        var result      = Endpoint.get( override );
+        var expectedUri = 'http://example.com/oauth/authorize?response_type=id_token%20token&client_id=client-id&redirect_uri=http%3A%2F%2Fexample.com%2Fredirect&scope=scope&state=';
+        expect( result ).toEqual( expectedUri );
+      });
+    });
   });
 });

--- a/test/spec/services/endpoint.js
+++ b/test/spec/services/endpoint.js
@@ -184,5 +184,14 @@ describe('Endpoint', function() {
         expect( result ).toEqual( expectedUri );
       });
     });
+
+    describe( "when provided with a nonce", function(){
+      it( "adds the nonce parameter", function(){
+        var override    = { nonce: '987654321' };
+        var result      = Endpoint.get( override );
+        var expectedUri = 'http://example.com/oauth/authorize?response_type=token&client_id=client-id&redirect_uri=http%3A%2F%2Fexample.com%2Fredirect&scope=scope&state=&nonce=987654321';
+        expect( result ).toEqual( expectedUri );
+      });
+    });
   });
 });

--- a/test/spec/services/endpoint.js
+++ b/test/spec/services/endpoint.js
@@ -96,12 +96,75 @@ describe('Endpoint', function() {
       Endpoint.set(params);
     });
 
-    beforeEach(function() {
-      result = Endpoint.get();
+    describe( "without overrides", function(){
+      beforeEach(function() {
+        result = Endpoint.get();
+      });
+
+      it('returns the oauth server endpoint', function() {
+        expect(result).toEqual(uri);
+      });
     });
 
-    it('returns the oauth server endpoint', function() {
-      expect(result).toEqual(uri);
+    describe( "with state override", function(){
+      it( "injects the state correct", function(){
+        var override = { state: 'testState' };
+        var result = Endpoint.get( override );
+        expect( result ).toEqual( uri + encodeURIComponent( override.state ) );
+      });
+    });
+
+    describe( "with clientId override", function(){
+      it( "injects the override", function(){
+        var override    = { clientId: 'unicorn' };
+        var result      = Endpoint.get( override );
+        var expectedUri = 'http://example.com/oauth/authorize?response_type=token&client_id=unicorn&redirect_uri=http%3A%2F%2Fexample.com%2Fredirect&scope=scope&state=';
+        expect( result ).toEqual( expectedUri );
+      });
+    });
+
+    describe( "with scope override", function(){
+      it( "injects the override", function(){
+        var override    = { scope: 'stars' };
+        var result      = Endpoint.get( override );
+        var expectedUri = 'http://example.com/oauth/authorize?response_type=token&client_id=client-id&redirect_uri=http%3A%2F%2Fexample.com%2Fredirect&scope=stars&state=';
+        expect( result ).toEqual( expectedUri );
+      });
+    });
+
+    describe( "with state override", function(){
+      it( "injects the state correct", function(){
+        var override = { state: 'testState' };
+        var result   = Endpoint.get( override );
+        expect( result ).toEqual( uri + encodeURIComponent( override.state ) );
+      });
+    });
+
+    describe( "with responseType override", function(){
+      it( "injects the correct repsonseType", function(){
+        var override    = { responseType: 'id_token' };
+        var result      = Endpoint.get( override );
+        var expectedUri = 'http://example.com/oauth/authorize?response_type=id_token&client_id=client-id&redirect_uri=http%3A%2F%2Fexample.com%2Fredirect&scope=scope&state=';
+        expect( result ).toEqual( expectedUri );
+      });
+    });
+
+    describe( "with site override", function(){
+      it( "injects the correct site", function(){
+        var override    = { site: 'https://invincible.test' };
+        var result      = Endpoint.get( override );
+        var expectedUri = 'https://invincible.test/oauth/authorize?response_type=token&client_id=client-id&redirect_uri=http%3A%2F%2Fexample.com%2Fredirect&scope=scope&state=';
+        expect( result ).toEqual( expectedUri );
+      });
+    });
+
+    describe( "with authorize path overrides", function(){
+      it( "injects the correct authorize path", function(){
+        var override    = { authorizePath: '/end/here' };
+        var result      = Endpoint.get( override );
+        var expectedUri = 'http://example.com/end/here?response_type=token&client_id=client-id&redirect_uri=http%3A%2F%2Fexample.com%2Fredirect&scope=scope&state=';
+        expect( result ).toEqual( expectedUri );
+      });
     });
   });
 });

--- a/test/spec/services/endpoint.js
+++ b/test/spec/services/endpoint.js
@@ -166,5 +166,14 @@ describe('Endpoint', function() {
         expect( result ).toEqual( expectedUri );
       });
     });
+
+    describe( "given scope with spaces", function(){
+      it( "correctly encodes the spaces", function(){
+        var override    = { scope: 'read write profile openid' };
+        var result      = Endpoint.get( override );
+        var expectedUri = 'http://example.com/oauth/authorize?response_type=token&client_id=client-id&redirect_uri=http%3A%2F%2Fexample.com%2Fredirect&scope=read%20write%20profile%20openid&state=';
+        expect( result ).toEqual( expectedUri );
+      });
+    });
   });
 });


### PR DESCRIPTION
I'm attempting to support an OpenID Connect 1.0 system using oauth-ng.  Given the UI requirements for displaying user profile information, the project can't use the oauth directive so we are using the associated components manually; so this doesn't include modifications to the tag itself.  I would be happy to add these if you feel like they provide enough value.

The attached patches adds support for URI encoding of the scope and request types as well as nonce on the Endpoint factory, including associated tests.  To allow for better capture of state and nonce I added the capability to override the configuration given to Endpoint#set in Endpoint#get.