### PR TITLE
fix #91 prevent two 'expired' events to be fired when refreshing the token

### DIFF
--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -152,7 +152,7 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
       return;
     }
     var time = (new Date(service.token.expires_at))-(new Date());
-    if(time){
+    if(time && time > 0){
       $interval(function(){
         $rootScope.$broadcast('oauth:expired', service.token);
       }, time, 1);


### PR DESCRIPTION
fixes #91