### PR TITLE
Protected resource interceptor #68

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -49,6 +49,7 @@
     <script src="scripts/services/endpoint.js"></script>
     <script src="scripts/services/profile.js"></script>
     <script src="scripts/services/storage.js"></script>
+    <script src="scripts/services/oauth-configuration.js"></script>
     <script src="scripts/interceptors/oauth-interceptor.js"></script>
     <script src="scripts/directives/oauth.js"></script>
     <!-- endbuild -->

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -7,7 +7,8 @@ angular.module('oauth', [
   'oauth.endpoint',       // oauth endpoint service
   'oauth.profile',        // profile model
   'oauth.storage',        // storage
-  'oauth.interceptor'     // bearer token interceptor
+  'oauth.interceptor',     // bearer token interceptor
+  'oauth.configuration'   // token appender
 ])
   .config(['$locationProvider','$httpProvider',
   function($locationProvider, $httpProvider) {

--- a/app/scripts/services/oauth-configuration.js
+++ b/app/scripts/services/oauth-configuration.js
@@ -21,7 +21,7 @@ oauthConfigurationService.provider('OAuthConfiguration', function() {
 .factory('AuthInterceptor', function($q, $rootScope, OAuthConfiguration, AccessToken) {
 	return {
 		'request': function(config) {
-			OAuthConfiguration.getConfig().protected_resources.forEach(function(resource) {
+			OAuthConfiguration.getConfig().protectedResources.forEach(function(resource) {
 				// If the url is one of the protected resources, we want to see if there's a token and then
 				// add the token if it exists.
 				if (config.url.indexOf(resource) > -1) {

--- a/app/scripts/services/oauth-configuration.js
+++ b/app/scripts/services/oauth-configuration.js
@@ -18,7 +18,7 @@ oauthConfigurationService.provider('OAuthConfiguration', function() {
 		};
 	};
 })
-.factory('AuthInterceptor', function($q, $rootScope, OAuthConfiguration, AccessToken) {
+.factory('AuthInterceptor', ['OAuthConfiguration', 'AccessToken', function(OAuthConfiguration, AccessToken) {
 	return {
 		'request': function(config) {
 			OAuthConfiguration.getConfig().protectedResources.forEach(function(resource) {
@@ -35,4 +35,4 @@ oauthConfigurationService.provider('OAuthConfiguration', function() {
 			return config;
 		}
 	};
-});
+}]);

--- a/app/scripts/services/oauth-configuration.js
+++ b/app/scripts/services/oauth-configuration.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var oauthConfigurationService = angular.module('oauth.configuration', []);
+
+oauthConfigurationService.provider('OAuthConfiguration', function() {
+	var _config = {};
+	
+	this.init = function(config, httpProvider) {
+		_config.protectedResources = config.protectedResources || [];
+		httpProvider.interceptors.push('AuthInterceptor');
+	};
+	
+	this.$get = function() {
+		return {
+			getConfig: function() {
+				return _config;
+			}
+		};
+	};
+})
+.factory('AuthInterceptor', function($q, $rootScope, OAuthConfiguration, AccessToken) {
+	return {
+		'request': function(config) {
+			OAuthConfiguration.getConfig().protected_resources.forEach(function(resource) {
+				// If the url is one of the protected resources, we want to see if there's a token and then
+				// add the token if it exists.
+				if (config.url.indexOf(resource) > -1) {
+					var token = AccessToken.get();
+					if (token) {
+						config.headers.Authorization = 'Bearer ' + token.access_token;
+					}
+				}
+			});
+			
+			return config;
+		}
+	};
+});

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -1,4 +1,4 @@
-/* oauth-ng - v0.4.2 - 2015-06-19 */
+/* oauth-ng - v0.4.2 - 2015-08-27 */
 
 'use strict';
 
@@ -9,7 +9,8 @@ angular.module('oauth', [
   'oauth.endpoint',       // oauth endpoint service
   'oauth.profile',        // profile model
   'oauth.storage',        // storage
-  'oauth.interceptor'     // bearer token interceptor
+  'oauth.interceptor',     // bearer token interceptor
+  'oauth.configuration'   // token appender
 ])
   .config(['$locationProvider','$httpProvider',
   function($locationProvider, $httpProvider) {
@@ -170,7 +171,7 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
       return;
     }
     var time = (new Date(service.token.expires_at))-(new Date());
-    if(time){
+    if(time && time > 0){
       $interval(function(){
         $rootScope.$broadcast('oauth:expired', service.token);
       }, time, 1);
@@ -331,6 +332,44 @@ storageService.factory('Storage', ['$rootScope', '$sessionStorage', '$localStora
 
   return service;
 }]);
+'use strict';
+
+var oauthConfigurationService = angular.module('oauth.configuration', []);
+
+oauthConfigurationService.provider('OAuthConfiguration', function() {
+	var _config = {};
+	
+	this.init = function(config, httpProvider) {
+		_config.protectedResources = config.protectedResources || [];
+		httpProvider.interceptors.push('AuthInterceptor');
+	};
+	
+	this.$get = function() {
+		return {
+			getConfig: function() {
+				return _config;
+			}
+		};
+	};
+})
+.factory('AuthInterceptor', function($q, $rootScope, OAuthConfiguration, AccessToken) {
+	return {
+		'request': function(config) {
+			OAuthConfiguration.getConfig().protected_resources.forEach(function(resource) {
+				// If the url is one of the protected resources, we want to see if there's a token and then
+				// add the token if it exists.
+				if (config.url.indexOf(resource) > -1) {
+					var token = AccessToken.get();
+					if (token) {
+						config.headers.Authorization = 'Bearer ' + token.access_token;
+					}
+				}
+			});
+			
+			return config;
+		}
+	};
+});
 'use strict';
 
 var interceptorService = angular.module('oauth.interceptor', []);

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -355,7 +355,7 @@ oauthConfigurationService.provider('OAuthConfiguration', function() {
 .factory('AuthInterceptor', function($q, $rootScope, OAuthConfiguration, AccessToken) {
 	return {
 		'request': function(config) {
-			OAuthConfiguration.getConfig().protected_resources.forEach(function(resource) {
+			OAuthConfiguration.getConfig().protectedResources.forEach(function(resource) {
 				// If the url is one of the protected resources, we want to see if there's a token and then
 				// add the token if it exists.
 				if (config.url.indexOf(resource) > -1) {

--- a/test/spec/services/oauth-configuration.js
+++ b/test/spec/services/oauth-configuration.js
@@ -1,0 +1,70 @@
+'use strict';
+
+describe('AuthInterceptor', function() {
+	var theOAuthConfigurationProvider, theOAuthConfiguration, OAuthConfiguration, AccessToken, AuthInterceptor, $location, result;
+	var protectedConfig, unprotectedConfig;
+	
+	beforeEach(module('oauth'));
+	
+	var expires_at = '2014-08-17T17:38:37.584Z';
+	var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path&extra=stuff'
+	
+	
+	beforeEach(function() {
+		var fakeModule = angular.module('test.app.config', function(){});
+		fakeModule.config(function(OAuthConfigurationProvider, $httpProvider) {
+			theOAuthConfigurationProvider = OAuthConfigurationProvider;
+			theOAuthConfigurationProvider.init({protectedResources:['http://api.protected']}, $httpProvider);
+			theOAuthConfiguration = theOAuthConfigurationProvider.$get();
+		})
+		module('oauth', 'test.app.config');
+		
+		inject(function() {});
+	})
+	
+	beforeEach(inject(function() { OAuthConfiguration = theOAuthConfiguration }));
+	beforeEach(inject(function($injector) { $location = $injector.get('$location'); }));
+	beforeEach(inject(function($injector) { AccessToken = $injector.get('AccessToken'); AccessToken.destroy(); } ));
+	beforeEach(inject(function($injector) { AuthInterceptor = $injector.get('AuthInterceptor'); }));
+	
+	beforeEach(function() {
+		protectedConfig = { url: 'http://api.protected', headers: { 'Accept': 'application/json'} };
+		unprotectedConfig = { url: 'http://api.unprotected', headers: { 'Accept': 'application/json' } };
+	});
+	
+	describe('when the resource is protected', function() {
+		beforeEach(function() {
+			$location.hash(fragment);
+			AccessToken.set();
+			result = AuthInterceptor.request(protectedConfig);
+		});
+		
+		it('should have the token in the header', function() {
+			expect(result.headers.Authorization).toEqual('Bearer token');
+		});
+	});
+	
+	describe('when the resource is unprotected', function() {
+		beforeEach(function() {
+			$location.hash(fragment);
+			AccessToken.set();
+			result = AuthInterceptor.request(unprotectedConfig);
+		});
+		
+		it('should not have the token in the header', function() {
+			expect(result.headers.Authorization).toBeUndefined();
+		});
+	});
+	
+	describe('when the user is not logged in', function() {
+		beforeEach(function() {
+			AccessToken.destroy();
+			result = AuthInterceptor.request(protectedConfig);
+		});
+		
+		it('should not have anything in the authorization header', function() {
+			expect(result.headers.Authorization).toBeUndefined();
+		});
+	});
+	
+})


### PR DESCRIPTION
Added the ability to easily configure an interceptor for certain resources to automatically append the token when it exists like requested in #68 . In the issue, the solutions discussed are to set the token for every request. The trouble with this is you end up leaking the token to resources where it's not necessary which could even be a pretty serious security concern in the right circumstances.

You just need to slap the following function into your angular config function.

```javascript
angular.module('myapp', ['oauth']).config(function($httpProvider, OAuthConfigurationProvider) {
    OAuthConfigurationProvider.init({
        protectedResources: [
            'http://myapi.mydomain.com',
            'http://myotherapi.mydomain.com'
        ]
    }, $httpProvider);
}
```

Now any requests to those URLs will have the token set in the headers, and any requests to other URLs will not have the token.

Note that you have to pass the $httpProvider.