### PR TITLE
(#101) Avoid flicker of login/logout/denied buttons

### DIFF
--- a/app/views/templates/button.html
+++ b/app/views/templates/button.html
@@ -1,5 +1,5 @@
 <span class="oauth">
-  <a href="#" class="logged-out" ng-show="show=='logged-out'" ng-click="login()">Login Button</a>
-  <a href="#" class="logged-in"  ng-show="show=='logged-in'"  ng-click="logout()">Logout {{profile.email}}</a>
-  <a href="#" class="denied"     ng-show="show=='denied'"     ng-click="login()">Access denied.</a>
+  <a href="#" class="logged-out ng-hide" ng-show="show=='logged-out'" ng-click="login()">Login Button</a>
+  <a href="#" class="logged-in ng-hide"  ng-show="show=='logged-in'"  ng-click="logout()">Logout {{profile.email}}</a>
+  <a href="#" class="denied ng-hide"     ng-show="show=='denied'"     ng-click="login()">Access denied.</a>
 </span>

--- a/app/views/templates/default.html
+++ b/app/views/templates/default.html
@@ -1,5 +1,5 @@
 <a class="oauth">
-  <span href="#" class="logged-out" ng-show="show=='logged-out'" ng-click="login()" >{{text}}</span>
-  <span href="#" class="logged-in"  ng-show="show=='logged-in'"  ng-click="logout()">Logout {{profile.email}}</span>
-  <span href="#" class="denied"     ng-show="show=='denied'"     ng-click="login()">Access denied. Try again.</span>
+  <span href="#" class="logged-out ng-hide" ng-show="show=='logged-out'" ng-click="login()" >{{text}}</span>
+  <span href="#" class="logged-in ng-hide"  ng-show="show=='logged-in'"  ng-click="logout()">Logout {{profile.email}}</span>
+  <span href="#" class="denied ng-hide"     ng-show="show=='denied'"     ng-click="login()">Access denied. Try again.</span>
 </a>


### PR DESCRIPTION
Currently, the 3 login, logout and denied buttons are shown before that 2 of them are hidden, which causes an unpleasant flicker. This happens because the AngularJS code takes time to kick-in.
Adding the "ng-hide" class to them hide them by default. This way, only the correct button will appear, after a short moment.