### PR TITLE
Webpack Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,6 @@
     "postinstall": "bower install",
     "clean": "rm -rf node_modules dist app/bower_components",
     "test": "grunt test && grunt build"
-  }
+  },
+  "main": "dist/oauth-ng.js"
 }


### PR DESCRIPTION
I'd like to be able to use this library from webpack by simply writing `import 'oauth-ng';`

This does the job.