### PR TITLE
Add Support for OpenID Connect Implicit Flow

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -41,7 +41,7 @@
     <!-- bower:js -->
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/ngstorage/ngStorage.js"></script>
-    <script src="bower_components/jsrsasign-latest-all-min/index.js"></script>
+    <script src="bower_components/jsrsasign/jsrsasign-latest-all-min.js"></script>
     <!-- endbower -->
 
     <!-- build:js({.tmp,app}) oauth-ng.js -->

--- a/app/index.html
+++ b/app/index.html
@@ -41,10 +41,12 @@
     <!-- bower:js -->
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/ngstorage/ngStorage.js"></script>
+    <script src="bower_components/jsrsasign-latest-all-min/index.js"></script>
     <!-- endbower -->
 
     <!-- build:js({.tmp,app}) oauth-ng.js -->
     <script src="scripts/app.js"></script>
+    <script src="scripts/services/id-token.js"></script>
     <script src="scripts/services/access-token.js"></script>
     <script src="scripts/services/endpoint.js"></script>
     <script src="scripts/services/profile.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -3,6 +3,7 @@
 // App libraries
 angular.module('oauth', [
   'oauth.directive',      // login directive
+  'oauth.idToken',        // id token service (only for OpenID Connect)
   'oauth.accessToken',    // access token service
   'oauth.endpoint',       // oauth endpoint service
   'oauth.profile',        // profile model

--- a/app/scripts/directives/oauth.js
+++ b/app/scripts/directives/oauth.js
@@ -33,7 +33,8 @@ directives.directive('oauth', [
         nonce: '@',          // (optional) Send nonce on auth request
                              // OIDC(OpenID Connect) extras:
         issuer: '@',         // (required for OpenID Connect) issuer of the id_token, should match the 'iss' claim in id_token payload
-        jwks: '@'            // (required for OpenID Connect) json web key(s), it will be used to verify the id_token signature
+        pubKey: '@'          // (optional for OpenID Connect) the public key(RSA public key or X509 certificate in PEM format) to verify the signature
+                             // If not set, the id_token header should carry information of the key or where to find the key
       }
     };
 

--- a/app/scripts/directives/oauth.js
+++ b/app/scripts/directives/oauth.js
@@ -3,6 +3,7 @@
 var directives = angular.module('oauth.directive', []);
 
 directives.directive('oauth', [
+  'IdToken',
   'AccessToken',
   'Endpoint',
   'Profile',
@@ -12,7 +13,7 @@ directives.directive('oauth', [
   '$compile',
   '$http',
   '$templateCache',
-  function(AccessToken, Endpoint, Profile, Storage, $location, $rootScope, $compile, $http, $templateCache) {
+  function(IdToken, AccessToken, Endpoint, Profile, Storage, $location, $rootScope, $compile, $http, $templateCache) {
 
     var definition = {
       restrict: 'AE',
@@ -29,7 +30,10 @@ directives.directive('oauth', [
         authorizePath: '@', // (optional) authorization url
         state: '@',         // (optional) An arbitrary unique string created by your app to guard against Cross-site Request Forgery
         storage: '@',        // (optional) Store token in 'sessionStorage' or 'localStorage', defaults to 'sessionStorage'
-        nonce: '@'          // (optional) Send nonce on auth request
+        nonce: '@',          // (optional) Send nonce on auth request
+                             // OIDC(OpenID Connect) extras:
+        issuer: '@',         // (required for OpenID Connect) issuer of the id_token, should match the 'iss' claim in id_token payload
+        jwks: '@'            // (required for OpenID Connect) json web key(s), it will be used to verify the id_token signature
       }
     };
 
@@ -45,6 +49,7 @@ directives.directive('oauth', [
         Storage.use(scope.storage);// set storage
         compile();                 // compiles the desired layout
         Endpoint.set(scope);       // sets the oauth authorization url
+        IdToken.set(scope);
         AccessToken.set(scope);    // sets the access token object (if existing, from fragment or session)
         initProfile(scope);        // gets the profile resource (if existing the access token)
         initView();                // sets the view (logged in or out)

--- a/app/scripts/directives/oauth.js
+++ b/app/scripts/directives/oauth.js
@@ -31,10 +31,10 @@ directives.directive('oauth', [
         state: '@',         // (optional) An arbitrary unique string created by your app to guard against Cross-site Request Forgery
         storage: '@',        // (optional) Store token in 'sessionStorage' or 'localStorage', defaults to 'sessionStorage'
         nonce: '@',          // (optional) Send nonce on auth request
-                             // OIDC(OpenID Connect) extras:
-        issuer: '@',         // (required for OpenID Connect) issuer of the id_token, should match the 'iss' claim in id_token payload
+                             // OpenID Connect extras, more details in id-token.js:
+        issuer: '@',         // (optional for OpenID Connect) issuer of the id_token, should match the 'iss' claim in id_token payload
+        subject: '@',        // (optional for OpenID Connect) subject of the id_token, should match the 'sub' claim in id_token payload
         pubKey: '@'          // (optional for OpenID Connect) the public key(RSA public key or X509 certificate in PEM format) to verify the signature
-                             // If not set, the id_token header should carry information of the key or where to find the key
       }
     };
 

--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -7,9 +7,12 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
   var service = {
     token: null
   },
-  oAuth2HashTokens = [ //per http://tools.ietf.org/html/rfc6749#section-4.2.2
+  hashFragmentKeys = [
+    //Oauth2 keys per http://tools.ietf.org/html/rfc6749#section-4.2.2
     'access_token', 'token_type', 'expires_in', 'scope', 'state',
-    'error','error_description'
+    'error','error_description',
+    //Additional OpenID Connect key per http://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthResponse
+    'id_token'
   ];
 
   /**
@@ -164,7 +167,7 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
    */
   var removeFragment = function(){
     var curHash = $location.hash();
-    angular.forEach(oAuth2HashTokens,function(hashKey){
+    angular.forEach(hashFragmentKeys,function(hashKey){
       var re = new RegExp('&'+hashKey+'(=[^&]*)?|^'+hashKey+'(=[^&]*)?&?');
       curHash = curHash.replace(re,'');
     });

--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -118,7 +118,15 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
 
     // OpenID Connect
     if (params.id_token) {
-      IdToken.validateIdToken(params.id_token);
+      try {
+        if (IdToken.validateIdToken(params.id_token)) {
+          IdToken.populateIdTokenClaims(params.id_token, params);
+        } else {
+          params.error = 'Failed to validate id_token';
+        }
+      } catch (error) {
+        params.error = 'Failed to validate id_token: ' + error.message;
+      }
       return params;
     }
 

--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -117,15 +117,28 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
     }
 
     // OpenID Connect
-    if (params.id_token) {
+    if (params.id_token && !params.error) {
+      var valid = false;
+      var message = '';
       try {
-        if (IdToken.validateIdToken(params.id_token)) {
-          IdToken.populateIdTokenClaims(params.id_token, params);
-        } else {
-          params.error = 'Failed to validate id_token';
+        valid = IdToken.validateIdToken(params.id_token);
+        /*
+          if response_type is 'id_token token', then we will get both id_token and access_token
+          access_token needs to be validated as well
+         */
+        if (valid && params.access_token) {
+          valid = IdToken.validateAccessToken(params.id_token, params.access_token);
         }
       } catch (error) {
-        params.error = 'Failed to validate id_token: ' + error.message;
+        message = error.message;
+      }
+
+      if (valid) {
+        IdToken.populateIdTokenClaims(params.id_token, params);
+      } else {
+        params.id_token = null;
+        params.access_token = null;
+        params.error = 'Failed to validate token:' + message;
       }
       return params;
     }

--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -118,28 +118,7 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
 
     // OpenID Connect
     if (params.id_token && !params.error) {
-      var valid = false;
-      var message = '';
-      try {
-        valid = IdToken.validateIdToken(params.id_token);
-        /*
-          if response_type is 'id_token token', then we will get both id_token and access_token
-          access_token needs to be validated as well
-         */
-        if (valid && params.access_token) {
-          valid = IdToken.validateAccessToken(params.id_token, params.access_token);
-        }
-      } catch (error) {
-        message = error.message;
-      }
-
-      if (valid) {
-        IdToken.populateIdTokenClaims(params.id_token, params);
-      } else {
-        params.id_token = null;
-        params.access_token = null;
-        params.error = 'Failed to validate token:' + message;
-      }
+      IdToken.validateTokensAndPopulateClaims(params);
       return params;
     }
 

--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -2,7 +2,7 @@
 
 var accessTokenService = angular.module('oauth.accessToken', []);
 
-accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location', '$interval', function(Storage, $rootScope, $location, $interval){
+accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location', '$interval', 'IdToken', function(Storage, $rootScope, $location, $interval, IdToken){
 
   var service = {
     token: null
@@ -116,6 +116,13 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
       params[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);
     }
 
+    // OpenID Connect
+    if (params.id_token) {
+      IdToken.validateIdToken(params.id_token);
+      return params;
+    }
+
+    // Oauth2
     if(params.access_token || params.error){
       return params;
     }

--- a/app/scripts/services/id-token.js
+++ b/app/scripts/services/id-token.js
@@ -37,7 +37,7 @@ accessTokenService.factory('IdToken', ['Storage', function(Storage){
      * @returns {boolean} True if all the check passes, False otherwise
      */
     service.validateIdToken = function(idToken) {
-      return verifyIdTokenSig(idToken) && verifyIdTokenInfo(idToken);
+      return this.verifyIdTokenSig(idToken) && this.verifyIdTokenInfo(idToken);
     };
 
     /**
@@ -56,10 +56,10 @@ accessTokenService.factory('IdToken', ['Storage', function(Storage){
      * @returns {boolean}          Indicates whether the signature is valid or not
      * @throws {OidcException}
      */
-    var verifyIdTokenSig = function (idtoken) {
+    service.verifyIdTokenSig = function (idtoken) {
       var verified = false;
 
-      if(!service.jwks) {
+      if(!this.jwks) {
         throw new OidcException('jwks(Json Web Keys) parameter not set');
       }
 
@@ -67,10 +67,10 @@ accessTokenService.factory('IdToken', ['Storage', function(Storage){
       var header = getJsonObject(idtParts[0]);
       var jwks = null;
 
-      if(typeof service.jwks === 'string')
-        jwks = getJsonObject(service.jwks);
-      else if(typeof service.jwks === 'object')
-        jwks = service.jwks;
+      if(typeof this.jwks === 'string')
+        jwks = getJsonObject(this.jwks);
+      else if(typeof this.jwks === 'object')
+        jwks = this.jwks;
 
       if(header.alg && header.alg.substr(0, 2) == 'RS') {
         var matchedPubKey = null;
@@ -98,7 +98,7 @@ accessTokenService.factory('IdToken', ['Storage', function(Storage){
      * @returns {boolean}           Validity of the ID Token
      * @throws {OidcException}
      */
-    var verifyIdTokenInfo = function(idtoken) {
+    service.verifyIdTokenInfo = function(idtoken) {
       var valid = false;
 
       if(idtoken) {
@@ -119,11 +119,11 @@ accessTokenService.factory('IdToken', ['Storage', function(Storage){
             } else
               audience = payload['aud'];
           }
-          if(audience && audience != service.clientId)
+          if(audience && audience != this.clientId)
             throw new OidcException('invalid audience');
 
-          if(payload['iss'] != service.issuer)
-            throw new OidcException('invalid issuer ' + payload['iss'] + ' != ' + service.clientId);
+          if(payload['iss'] != this.issuer)
+            throw new OidcException('invalid issuer ' + payload['iss'] + ' != ' + this.issuer);
 
           //TODO: nonce support ? probably need to redo current nonce support
           //if(payload['nonce'] != sessionStorage['nonce'])

--- a/app/scripts/services/id-token.js
+++ b/app/scripts/services/id-token.js
@@ -177,10 +177,10 @@ idTokenService.factory('IdToken', ['Storage', function(Storage) {
         if (now < payload.ntb)
           throw new OidcException('ID Token is invalid before '+ payload.ntb);
 
-        if (payload.iss && this.issuer && payload.iss != this.issuer)
+        if (payload.iss && this.issuer && payload.iss !== this.issuer)
           throw new OidcException('Invalid issuer ' + payload.iss + ' != ' + this.issuer);
 
-        if (payload.sub && this.subject && payload.sub != this.subject)
+        if (payload.sub && this.subject && payload.sub !== this.subject)
           throw new OidcException('Invalid subject ' + payload.sub + ' != ' + this.subject);
 
         if (payload.aud) {

--- a/app/scripts/services/id-token.js
+++ b/app/scripts/services/id-token.js
@@ -2,8 +2,7 @@
 
 var accessTokenService = angular.module('oauth.idToken', []);
 
-accessTokenService.factory('IdToken', ['Storage', '$rootScope', '$location',
-  function(Storage, $rootScope, $location){
+accessTokenService.factory('IdToken', ['Storage', function(Storage){
 
     var service = {
       issuer: null,
@@ -126,7 +125,7 @@ accessTokenService.factory('IdToken', ['Storage', '$rootScope', '$location',
           if(payload['iss'] != service.issuer)
             throw new OidcException('invalid issuer ' + payload['iss'] + ' != ' + service.clientId);
 
-          //TODO: nonce support
+          //TODO: nonce support ? probably need to redo current nonce support
           //if(payload['nonce'] != sessionStorage['nonce'])
           //  throw new OidcException('invalid nonce');
           valid = true;

--- a/app/scripts/services/id-token.js
+++ b/app/scripts/services/id-token.js
@@ -42,6 +42,15 @@ accessTokenService.factory('IdToken', ['Storage', '$rootScope', '$location',
     };
 
     /**
+     * Populate id token claims to map for future use
+     * @param idToken The id_token
+     * @param params  The target object for storing the claims
+     */
+    service.populateIdTokenClaims = function(idToken, params) {
+      params.id_token_claims = getIdTokenPayload(idToken);
+    };
+
+    /**
      * Verifies the ID Token signature using the JWK Keyset from jwks
      * Supports only RSA signatures
      * @param {string}idtoken      The ID Token string
@@ -143,7 +152,7 @@ accessTokenService.factory('IdToken', ['Storage', '$rootScope', '$location',
 
     /**
      * Splits the ID Token string into the individual JWS parts
-     * @param  {string} id_token    - ID Token
+     * @param  {string} id_token  ID Token
      * @returns {Array} An array of the JWS compact serialization components (header, payload, signature)
      */
     var getIdTokenParts = function (id_token) {
@@ -154,8 +163,8 @@ accessTokenService.factory('IdToken', ['Storage', '$rootScope', '$location',
 
     /**
      * Get the contents of the ID Token payload as an JSON object
-     * @param {string} id_token     - ID Token
-     * @returns {object}            - The ID Token payload JSON object
+     * @param {string} id_token     ID Token
+     * @returns {object}            The ID Token payload JSON object
      */
     var getIdTokenPayload = function (id_token) {
       var parts = getIdTokenParts(id_token);
@@ -165,7 +174,7 @@ accessTokenService.factory('IdToken', ['Storage', '$rootScope', '$location',
 
     /**
      * Get the JSON object from the JSON string
-     * @param {string} jsonS    - JSON string
+     * @param {string} jsonS    JSON string
      * @returns {object|null}   JSON object or null
      */
     var getJsonObject = function (jsonS) {
@@ -178,11 +187,11 @@ accessTokenService.factory('IdToken', ['Storage', '$rootScope', '$location',
 
     /**
      * Retrieve the JWK key that matches the input criteria
-     * @param {array} keys              - JWK Keyset
-     * @param {string} kty              - The 'kty' to match (RSA|EC). Only RSA is supported.
-     * @param {string} use              - The 'use' to match (sig|enc).
-     * @param {string} kid              - The 'kid' to match
-     * @returns {object} jwk            - The matched JWK
+     * @param {array} keys               JWK Keyset
+     * @param {string} kty               The 'kty' to match (RSA|EC). Only RSA is supported.
+     * @param {string} use               The 'use' to match (sig|enc).
+     * @param {string} kid               The 'kid' to match
+     * @returns {object} jwk             The matched JWK
      */
     var getMatchedKey = function (keys, kty, use, kid) {
       var foundKeys = [];

--- a/app/scripts/services/id-token.js
+++ b/app/scripts/services/id-token.js
@@ -1,0 +1,248 @@
+'use strict';
+
+var accessTokenService = angular.module('oauth.idToken', []);
+
+accessTokenService.factory('IdToken', ['Storage', '$rootScope', '$location',
+  function(Storage, $rootScope, $location){
+
+    var service = {
+      issuer: null,
+      clientId: null,
+      jwks: null
+    };
+    /**
+     * OidcException
+     * @param {string } message  - The exception error message
+     * @constructor
+     */
+    function OidcException(message) {
+      this.name = 'OidcException';
+      this.message = message;
+    }
+    OidcException.prototype = new Error();
+    OidcException.prototype.constructor = OidcException;
+
+    /**
+     * For initialization
+     * @param scope
+     */
+    service.set = function(scope) {
+      this.issuer = scope.issuer;
+      this.clientId = scope.clientId;
+      this.jwks = scope.jwks;
+    };
+
+    /**
+     * Validates the id_token
+     * @param {String} idToken The id_token
+     * @returns {boolean} True if all the check passes, False otherwise
+     */
+    service.validateIdToken = function(idToken) {
+      return verifyIdTokenSig(idToken) && verifyIdTokenInfo(idToken);
+    };
+
+    /**
+     * Verifies the ID Token signature using the JWK Keyset from jwks
+     * Supports only RSA signatures
+     * @param {string}idtoken      The ID Token string
+     * @returns {boolean}          Indicates whether the signature is valid or not
+     * @throws {OidcException}
+     */
+    var verifyIdTokenSig = function (idtoken) {
+      var verified = false;
+
+      if(!service.jwks) {
+        throw new OidcException('jwks(Json Web Keys) parameter not set');
+      }
+
+      var idtParts = getIdTokenParts(idtoken);
+      var header = getJsonObject(idtParts[0]);
+      var jwks = service.jwks.keys;
+
+      if(header['alg'] && header['alg'].substr(0, 2) == 'RS') {
+        //TODO: choose key ?
+        //var jwk = jwk_get_key(jwks, 'RSA', 'sig', header['kid']);
+        verified = rsaVerifyJWS(idtoken, jwks[0]);
+        //if(!jwk)
+        //  new OidcException('No matching JWK found');
+        //else {
+        //  console.log("-----4------");
+        //  verified = rsaVerifyJWS(idtoken, jwk[0]);
+        //}
+      } else
+        throw new OidcException('Unsupported JWS signature algorithm ' + header['alg']);
+
+      return verified;
+    };
+
+    /**
+     * Validates the information in the ID Token against configuration
+     * @param {string} idtoken      The ID Token string
+     * @returns {boolean}           Validity of the ID Token
+     * @throws {OidcException}
+     */
+    var verifyIdTokenInfo = function(idtoken) {
+      var valid = false;
+
+      if(idtoken) {
+        var idtParts = getIdTokenParts(idtoken);
+        var payload = getJsonObject(idtParts[1]);
+        if(payload) {
+          var now =  new Date() / 1000;
+          if( payload['iat'] >  now + 60)
+            throw new OidcException('ID Token issued time is later than current time');
+
+          if(payload['exp'] < now - 60)
+            throw new OidcException('ID Token expired');
+
+          var audience = null;
+          if(payload['aud']) {
+            if(payload['aud'] instanceof Array) {
+              audience = payload['aud'][0];
+            } else
+              audience = payload['aud'];
+          }
+          if(audience && audience != service.clientId)
+            throw new OidcException('invalid audience');
+
+          if(payload['iss'] != service.issuer)
+            throw new OidcException('invalid issuer ' + payload['iss'] + ' != ' + service.clientId);
+
+          //TODO: nonce support
+          //if(payload['nonce'] != sessionStorage['nonce'])
+          //  throw new OidcException('invalid nonce');
+          valid = true;
+        } else
+          throw new OidcException('Unable to parse JWS payload');
+      }
+      return valid;
+    };
+
+    /**
+     * Verifies the JWS string using the JWK
+     * @param {string} jws      The JWS string
+     * @param {object} jwk      The JWK Key that will be used to verify the signature
+     * @returns {boolean}       Validity of the JWS signature
+     * @throws {OidcException}
+     */
+    var rsaVerifyJWS = function (jws, jwk) {
+      if(jws && typeof jwk === 'object') {
+        return KJUR.jws.JWS.verify(jws, jwk, ['RS256']);
+        //if(jwk['kty'] == 'RSA') {
+        //  var verifier = new KJUR.jws.JWS();
+        //  if(jwk['n'] && jwk['e']) {
+        //    var keyN = b64utohex(jwk['n']);
+        //    var keyE = b64utohex(jwk['e']);
+        //    return verifier.verifyJWSByNE(jws, keyN, keyE);
+        //  } else if (jwk['x5c']) {
+        //    return verifier.verifyJWSByPemX509Cert(jws, "-----BEGIN CERTIFICATE-----\n" + jwk['x5c'][0] + "\n-----END CERTIFICATE-----\n");
+        //  }
+        //} else {
+        //  throw new OidcException('No RSA kty in JWK');
+        //}
+      }
+      return false;
+    };
+
+    /**
+     * Splits the ID Token string into the individual JWS parts
+     * @param  {string} id_token    - ID Token
+     * @returns {Array} An array of the JWS compact serialization components (header, payload, signature)
+     */
+    var getIdTokenParts = function (id_token) {
+      var jws = new KJUR.jws.JWS();
+      jws.parseJWS(id_token);
+      return [jws.parsedJWS.headS, jws.parsedJWS.payloadS, jws.parsedJWS.si];
+    };
+
+    /**
+     * Get the contents of the ID Token payload as an JSON object
+     * @param {string} id_token     - ID Token
+     * @returns {object}            - The ID Token payload JSON object
+     */
+    var getIdTokenPayload = function (id_token) {
+      var parts = getIdTokenParts(id_token);
+      if(parts)
+        return getJsonObject(parts[1]);
+    };
+
+    /**
+     * Get the JSON object from the JSON string
+     * @param {string} jsonS    - JSON string
+     * @returns {object|null}   JSON object or null
+     */
+    var getJsonObject = function (jsonS) {
+      var jws = KJUR.jws.JWS;
+      if(jws.isSafeJSONString(jsonS)) {
+        return jws.readSafeJSONString(jsonS);
+      }
+      return null;
+    };
+
+    /**
+     * Retrieve the JWK key that matches the input criteria
+     * @param {string|object} jwkIn     - JWK Keyset string or object
+     * @param {string} kty              - The 'kty' to match (RSA|EC). Only RSA is supported.
+     * @param {string}use               - The 'use' to match (sig|enc).
+     * @param {string}kid               - The 'kid' to match
+     * @returns {array}                 Array of JWK keys that match the specified criteria                                                                     itera
+     */
+    var jwk_get_key = function(jwkIn, kty, use, kid )
+    {
+      var jwk = null;
+      var foundKeys = [];
+
+      if(jwkIn) {
+        if(typeof jwkIn === 'string')
+          jwk = getJsonObject(jwkIn);
+        else if(typeof jwkIn === 'object')
+          jwk = jwkIn;
+
+        if(jwk != null) {
+          if(typeof jwk['keys'] === 'object') {
+            if(jwk.keys.length == 0)
+              return null;
+
+            for(var i = 0; i < jwk.keys.length; i++) {
+              if(jwk['keys'][i]['kty'] == kty)
+                foundKeys.push(jwk.keys[i]);
+            }
+
+            if(foundKeys.length == 0)
+              return null;
+
+            if(use) {
+              var temp = [];
+              for(var j = 0; j < foundKeys.length; j++) {
+                if(!foundKeys[j]['use'])
+                  temp.push(foundKeys[j]);
+                else if(foundKeys[j]['use'] == use)
+                  temp.push(foundKeys[j]);
+              }
+              foundKeys = temp;
+            }
+            if(foundKeys.length == 0)
+              return null;
+
+            if(kid) {
+              temp = [];
+              for(var k = 0; k < foundKeys.length; k++) {
+                if(foundKeys[k]['kid'] == kid)
+                  temp.push(foundKeys[k]);
+              }
+              foundKeys = temp;
+            }
+            if(foundKeys.length == 0)
+              return null;
+            else
+              return foundKeys;
+          }
+        }
+      }
+    };
+
+
+
+    return service;
+
+}]);

--- a/app/scripts/services/id-token.js
+++ b/app/scripts/services/id-token.js
@@ -51,7 +51,7 @@ accessTokenService.factory('IdToken', ['Storage', function(Storage){
 
     /**
      * Verifies the ID Token signature using the JWK Keyset from jwks
-     * Supports only RSA signatures
+     * Supports only RSA signatures ['RS256', 'RS384', 'RS512']
      * @param {string}idtoken      The ID Token string
      * @returns {boolean}          Indicates whether the signature is valid or not
      * @throws {OidcException}
@@ -72,7 +72,7 @@ accessTokenService.factory('IdToken', ['Storage', function(Storage){
       else if(typeof service.jwks === 'object')
         jwks = service.jwks;
 
-      if(header['alg'] && header['alg'].substr(0, 2) == 'RS') {
+      if(header.alg && header.alg.substr(0, 2) == 'RS') {
         var matchedPubKey = null;
         if (jwks.keys) {
           if (jwks.keys.length == 1) {
@@ -84,10 +84,10 @@ accessTokenService.factory('IdToken', ['Storage', function(Storage){
         if (!matchedPubKey) {
           throw new OidcException('No matching JWK found');
         } else {
-          verified = rsaVerifyJWS(idtoken, matchedPubKey);
+          verified = rsaVerifyJWS(idtoken, matchedPubKey, header.alg);
         }
       } else
-        throw new OidcException('Unsupported JWS signature algorithm ' + header['alg']);
+        throw new OidcException('Unsupported JWS signature algorithm ' + header.alg);
 
       return verified;
     };
@@ -139,12 +139,14 @@ accessTokenService.factory('IdToken', ['Storage', function(Storage){
      * Verifies the JWS string using the JWK
      * @param {string} jws      The JWS string
      * @param {object} jwk      The JWK Key that will be used to verify the signature
+     * @param {string} alg      The algorithm string. Expecting 'RS256', 'RS384', or 'RS512'
      * @returns {boolean}       Validity of the JWS signature
      * @throws {OidcException}
      */
-    var rsaVerifyJWS = function (jws, jwk) {
+    var rsaVerifyJWS = function (jws, jwk, alg) {
       if(jws && typeof jwk === 'object') {
-        return KJUR.jws.JWS.verify(jws, jwk, ['RS256']);
+        console.log("verifying token with algorithm ["+alg+"]");
+        return KJUR.jws.JWS.verify(jws, jwk, [alg]);
       }
       return false;
     };

--- a/app/scripts/services/id-token.js
+++ b/app/scripts/services/id-token.js
@@ -1,271 +1,215 @@
 'use strict';
 
-var accessTokenService = angular.module('oauth.idToken', []);
+var idTokenService = angular.module('oauth.idToken', []);
 
-accessTokenService.factory('IdToken', ['Storage', function(Storage){
+idTokenService.factory('IdToken', ['Storage', function(Storage){
 
-    var service = {
-      issuer: null,
-      clientId: null,
-      jwks: null
-    };
-    /**
-     * OidcException
-     * @param {string } message  - The exception error message
-     * @constructor
-     */
-    function OidcException(message) {
-      this.name = 'OidcException';
-      this.message = message;
+  var service = {
+    issuer: null,
+    clientId: null,
+    pubKey: null
+  };
+  /**
+   * OidcException
+   * @param {string } message  - The exception error message
+   * @constructor
+   */
+  function OidcException(message) {
+    this.name = 'OidcException';
+    this.message = message;
+  }
+  OidcException.prototype = new Error();
+  OidcException.prototype.constructor = OidcException;
+
+  /**
+   * For initialization
+   * @param scope
+   */
+  service.set = function(scope) {
+    this.issuer = scope.issuer;
+    this.clientId = scope.clientId;
+    this.pubKey = scope.pubKey;
+  };
+
+  /**
+   * Validates the id_token
+   * @param {String} idToken The id_token
+   * @returns {boolean} True if all the check passes, False otherwise
+   */
+  service.validateIdToken = function(idToken) {
+    return this.verifyIdTokenSig(idToken) && this.verifyIdTokenInfo(idToken);
+  };
+
+  /**
+   * Populate id token claims to map for future use
+   * @param idToken The id_token
+   * @param params  The target object for storing the claims
+   */
+  service.populateIdTokenClaims = function(idToken, params) {
+    params.id_token_claims = getIdTokenPayload(idToken);
+  };
+
+  /**
+   * Validate access_token based on the 'alg' and 'at_hash' value of the id_token header
+   * per spec: http://openid.net/specs/openid-connect-core-1_0.html#ImplicitTokenValidation
+   *
+   * @param idToken The id_token
+   * @param accessToken The access_token
+   * @returns {boolean} true if validation passes
+   */
+  service.validateAccessToken = function(idToken, accessToken) {
+    var header = getJsonObject(getIdTokenParts(idToken)[0]);
+    if (header.at_hash) {
+      var shalevel = header.alg.substr(2);
+      if (shalevel !== '256' && shalevel !== '384' && shalevel !== '512') {
+        throw new OidcException('Unsupported hash algorithm, expecting sha256, sha384, or sha512');
+      }
+      var md = new KJUR.crypto.MessageDigest({'alg':'sha'+ shalevel, 'prov':'cryptojs'});
+      //hex representation of the hash
+      var hexStr = md.digestString(accessToken);
+      //take first 128bits and base64url encoding it
+      var expected = hextob64u(hexStr.substring(0, 32));
+
+      return expected === header.at_hash;
+    } else {
+      return true;
     }
-    OidcException.prototype = new Error();
-    OidcException.prototype.constructor = OidcException;
+  };
 
-    /**
-     * For initialization
-     * @param scope
-     */
-    service.set = function(scope) {
-      this.issuer = scope.issuer;
-      this.clientId = scope.clientId;
-      this.jwks = scope.jwks;
-    };
+  /**
+   * Verifies the ID Token signature using the specified public key
+   * The id_token header can optionally carry public key or the url to retrieve the public key
+   * Otherwise will use the public key configured using 'pubKey'
+   *
+   * Supports only RSA signatures ['RS256', 'RS384', 'RS512']
+   * @param {string}idToken      The ID Token string
+   * @returns {boolean}          Indicates whether the signature is valid or not
+   * @throws {OidcException}
+   */
+  service.verifyIdTokenSig = function (idToken) {
 
-    /**
-     * Validates the id_token
-     * @param {String} idToken The id_token
-     * @returns {boolean} True if all the check passes, False otherwise
-     */
-    service.validateIdToken = function(idToken) {
-      return this.verifyIdTokenSig(idToken) && this.verifyIdTokenInfo(idToken);
-    };
+    var idtParts = getIdTokenParts(idToken);
+    var header = getJsonObject(idtParts[0]);
 
-    /**
-     * Populate id token claims to map for future use
-     * @param idToken The id_token
-     * @param params  The target object for storing the claims
-     */
-    service.populateIdTokenClaims = function(idToken, params) {
-      params.id_token_claims = getIdTokenPayload(idToken);
-    };
+    if(!header.alg || header.alg.substr(0, 2) !== 'RS') {
+      throw new OidcException('Unsupported JWS signature algorithm ' + header.alg);
+    }
 
-    /**
-     * Validate access_token based on the 'alg' and 'at_hash' value of the id_token header
-     * per spec: http://openid.net/specs/openid-connect-core-1_0.html#ImplicitTokenValidation
-     *
-     * @param idToken The id_token
-     * @param accessToken The access_token
-     * @returns {boolean} true if validation passes
-     */
-    service.validateAccessToken = function(idToken, accessToken) {
-      var header = getJsonObject(getIdTokenParts(idToken)[0]);
-      if (header.at_hash) {
-        var shalevel = header.alg.substr(2);
-        if (shalevel !== '256' && shalevel !== '384' && shalevel !== '512') {
-          throw new OidcException('Unsupported hash algorithm, expecting sha256, sha384, or sha512');
-        }
-        var md = new KJUR.crypto.MessageDigest({'alg':'sha'+ shalevel, 'prov':'cryptojs'});
-        //hex representation of the hash
-        var hexStr = md.digestString(accessToken);
-        //take first 128bits and base64url encoding it
-        var expected = hextob64u(hexStr.substring(0, 32));
+    var matchedPubKey = null;
 
-        return expected === header.at_hash;
-      } else {
-        return true;
+    if (header.jwk) {
+      //Take the JWK if it comes with the id_token
+      matchedPubKey = header.jwk;
+      if (matchedPubKey.kid && header.kid && matchedPubKey.kid !== header.kid) {
+        throw new OidcException('Json Wek Key ID not match');
       }
-    };
-
-    /**
-     * Verifies the ID Token signature using the JWK Keyset from jwks
-     * Supports only RSA signatures ['RS256', 'RS384', 'RS512']
-     * @param {string}idtoken      The ID Token string
-     * @returns {boolean}          Indicates whether the signature is valid or not
-     * @throws {OidcException}
-     */
-    service.verifyIdTokenSig = function (idtoken) {
-      var verified = false;
-
-      if(!this.jwks) {
-        throw new OidcException('jwks(Json Web Keys) parameter not set');
+      //TODO: Support for "jku" (JWK Set URL), "x5u" (X.509 URL), "x5c" (X.509 Certificate Chain) parameter to get key
+    } else {
+      //Use configured public key
+      matchedPubKey = this.pubKey;
+      if (typeof matchedPubKey !== 'string') {
+        throw new OidcException('Unsupported public key format, expecting PEM format');
       }
+    }
 
+    if(!matchedPubKey) {
+      throw new OidcException('No public key found to verify signature');
+    }
+
+    return rsaVerifyJWS(idToken, matchedPubKey, header.alg);
+  };
+
+  /**
+   * Validates the information in the ID Token against configuration
+   * @param {string} idtoken      The ID Token string
+   * @returns {boolean}           Validity of the ID Token
+   * @throws {OidcException}
+   */
+  service.verifyIdTokenInfo = function(idtoken) {
+    var valid = false;
+
+    if(idtoken) {
       var idtParts = getIdTokenParts(idtoken);
-      var header = getJsonObject(idtParts[0]);
-      var jwks = null;
+      var payload = getJsonObject(idtParts[1]);
+      if(payload) {
+        var now =  new Date() / 1000;
+        if( payload['iat'] >  now )
+          throw new OidcException('ID Token issued time is later than current time');
 
-      if(typeof this.jwks === 'string')
-        jwks = getJsonObject(this.jwks);
-      else if(typeof this.jwks === 'object')
-        jwks = this.jwks;
+        if(payload['exp'] < now )
+          throw new OidcException('ID Token expired');
 
-      if(header.alg && header.alg.substr(0, 2) == 'RS') {
-        var matchedPubKey = null;
-        if (jwks.keys) {
-          if (jwks.keys.length == 1) {
-            matchedPubKey = jwks.keys[0];
-          } else {
-            matchedPubKey = getMatchedKey(jwks.keys, 'RSA', 'sig', header.kid);
-          }
+        var audience = null;
+        if(payload['aud']) {
+          if(payload['aud'] instanceof Array) {
+            audience = payload['aud'][0];
+          } else
+            audience = payload['aud'];
         }
-        if (!matchedPubKey) {
-          throw new OidcException('No matching JWK found');
-        } else {
-          verified = rsaVerifyJWS(idtoken, matchedPubKey, header.alg);
-        }
+        if(audience && audience != this.clientId)
+          throw new OidcException('invalid audience');
+
+        if(payload['iss'] != this.issuer)
+          throw new OidcException('invalid issuer ' + payload['iss'] + ' != ' + this.issuer);
+
+        //TODO: nonce support ? probably need to redo current nonce support
+        //if(payload['nonce'] != sessionStorage['nonce'])
+        //  throw new OidcException('invalid nonce');
+        valid = true;
       } else
-        throw new OidcException('Unsupported JWS signature algorithm ' + header.alg);
+        throw new OidcException('Unable to parse JWS payload');
+    }
+    return valid;
+  };
 
-      return verified;
-    };
+  /**
+   * Verifies the JWS string using the JWK
+   * @param {string} jws      The JWS string
+   * @param {object} pubKey   The public key that will be used to verify the signature
+   * @param {string} alg      The algorithm string. Expecting 'RS256', 'RS384', or 'RS512'
+   * @returns {boolean}       Validity of the JWS signature
+   * @throws {OidcException}
+   */
+  var rsaVerifyJWS = function (jws, pubKey, alg) {
+    var rsaKey = KEYUTIL.getKey(pubKey);
+    return KJUR.jws.JWS.verify(jws, rsaKey, [alg]);
+  };
 
-    /**
-     * Validates the information in the ID Token against configuration
-     * @param {string} idtoken      The ID Token string
-     * @returns {boolean}           Validity of the ID Token
-     * @throws {OidcException}
-     */
-    service.verifyIdTokenInfo = function(idtoken) {
-      var valid = false;
+  /**
+   * Splits the ID Token string into the individual JWS parts
+   * @param  {string} id_token  ID Token
+   * @returns {Array} An array of the JWS compact serialization components (header, payload, signature)
+   */
+  var getIdTokenParts = function (id_token) {
+    var jws = new KJUR.jws.JWS();
+    jws.parseJWS(id_token);
+    return [jws.parsedJWS.headS, jws.parsedJWS.payloadS, jws.parsedJWS.si];
+  };
 
-      if(idtoken) {
-        var idtParts = getIdTokenParts(idtoken);
-        var payload = getJsonObject(idtParts[1]);
-        if(payload) {
-          var now =  new Date() / 1000;
-          if( payload['iat'] >  now )
-            throw new OidcException('ID Token issued time is later than current time');
+  /**
+   * Get the contents of the ID Token payload as an JSON object
+   * @param {string} id_token     ID Token
+   * @returns {object}            The ID Token payload JSON object
+   */
+  var getIdTokenPayload = function (id_token) {
+    var parts = getIdTokenParts(id_token);
+    if(parts)
+      return getJsonObject(parts[1]);
+  };
 
-          if(payload['exp'] < now )
-            throw new OidcException('ID Token expired');
+  /**
+   * Get the JSON object from the JSON string
+   * @param {string} jsonS    JSON string
+   * @returns {object|null}   JSON object or null
+   */
+  var getJsonObject = function (jsonS) {
+    var jws = KJUR.jws.JWS;
+    if(jws.isSafeJSONString(jsonS)) {
+      return jws.readSafeJSONString(jsonS);
+    }
+    return null;
+  };
 
-          var audience = null;
-          if(payload['aud']) {
-            if(payload['aud'] instanceof Array) {
-              audience = payload['aud'][0];
-            } else
-              audience = payload['aud'];
-          }
-          if(audience && audience != this.clientId)
-            throw new OidcException('invalid audience');
-
-          if(payload['iss'] != this.issuer)
-            throw new OidcException('invalid issuer ' + payload['iss'] + ' != ' + this.issuer);
-
-          //TODO: nonce support ? probably need to redo current nonce support
-          //if(payload['nonce'] != sessionStorage['nonce'])
-          //  throw new OidcException('invalid nonce');
-          valid = true;
-        } else
-          throw new OidcException('Unable to parse JWS payload');
-      }
-      return valid;
-    };
-
-    /**
-     * Verifies the JWS string using the JWK
-     * @param {string} jws      The JWS string
-     * @param {object} jwk      The JWK Key that will be used to verify the signature
-     * @param {string} alg      The algorithm string. Expecting 'RS256', 'RS384', or 'RS512'
-     * @returns {boolean}       Validity of the JWS signature
-     * @throws {OidcException}
-     */
-    var rsaVerifyJWS = function (jws, jwk, alg) {
-      if(jws && typeof jwk === 'object') {
-        console.log("verifying token with algorithm ["+alg+"]");
-        return KJUR.jws.JWS.verify(jws, jwk, [alg]);
-      }
-      return false;
-    };
-
-    /**
-     * Splits the ID Token string into the individual JWS parts
-     * @param  {string} id_token  ID Token
-     * @returns {Array} An array of the JWS compact serialization components (header, payload, signature)
-     */
-    var getIdTokenParts = function (id_token) {
-      var jws = new KJUR.jws.JWS();
-      jws.parseJWS(id_token);
-      return [jws.parsedJWS.headS, jws.parsedJWS.payloadS, jws.parsedJWS.si];
-    };
-
-    /**
-     * Get the contents of the ID Token payload as an JSON object
-     * @param {string} id_token     ID Token
-     * @returns {object}            The ID Token payload JSON object
-     */
-    var getIdTokenPayload = function (id_token) {
-      var parts = getIdTokenParts(id_token);
-      if(parts)
-        return getJsonObject(parts[1]);
-    };
-
-    /**
-     * Get the JSON object from the JSON string
-     * @param {string} jsonS    JSON string
-     * @returns {object|null}   JSON object or null
-     */
-    var getJsonObject = function (jsonS) {
-      var jws = KJUR.jws.JWS;
-      if(jws.isSafeJSONString(jsonS)) {
-        return jws.readSafeJSONString(jsonS);
-      }
-      return null;
-    };
-
-    /**
-     * Retrieve the JWK key that matches the input criteria
-     * @param {array} keys               JWK Keyset
-     * @param {string} kty               The 'kty' to match (RSA|EC). Only RSA is supported.
-     * @param {string} use               The 'use' to match (sig|enc).
-     * @param {string} kid               The 'kid' to match
-     * @returns {object} jwk             The matched JWK
-     */
-    var getMatchedKey = function (keys, kty, use, kid) {
-      var foundKeys = [];
-
-      if (typeof keys === 'object' && keys.length > 0) {
-        for (var i = 0; i < keys.length; i++) {
-          if (keys[i]['kty'] == kty)
-            foundKeys.push(keys[i]);
-        }
-
-        if (foundKeys.length == 0)
-          return null;
-
-        if (use) {
-          var temp = [];
-          for (var j = 0; j < foundKeys.length; j++) {
-            if (!foundKeys[j]['use'])
-              temp.push(foundKeys[j]);
-            else if (foundKeys[j]['use'] == use)
-              temp.push(foundKeys[j]);
-          }
-          foundKeys = temp;
-        }
-        if (foundKeys.length == 0)
-          return null;
-
-        if (kid) {
-          temp = [];
-          for (var k = 0; k < foundKeys.length; k++) {
-            if (foundKeys[k]['kid'] == kid)
-              temp.push(foundKeys[k]);
-          }
-          foundKeys = temp;
-        }
-        if (foundKeys.length == 0)
-          return null;
-        else
-          return foundKeys[0];
-      } else {
-        return null;
-      }
-
-    };
-
-
-
-    return service;
+  return service;
 
 }]);

--- a/app/scripts/services/id-token.js
+++ b/app/scripts/services/id-token.js
@@ -55,7 +55,7 @@ idTokenService.factory('IdToken', ['Storage', function(Storage) {
     }
 
     if (valid) {
-      this.populateIdTokenClaims(params.id_token, params);
+      params.id_token_claims = getIdTokenPayload(params.id_token);
     } else {
       params.id_token = null;
       params.access_token = null;
@@ -71,15 +71,6 @@ idTokenService.factory('IdToken', ['Storage', function(Storage) {
    */
   service.validateIdToken = function(idToken) {
     return this.verifyIdTokenSig(idToken) && this.verifyIdTokenInfo(idToken);
-  };
-
-  /**
-   * Populate id token claims to map for future use
-   * @param idToken The id_token
-   * @param params  The target object for storing the claims
-   */
-  service.populateIdTokenClaims = function(idToken, params) {
-    params.id_token_claims = getIdTokenPayload(idToken);
   };
 
   /**

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
   ],
   "dependencies": {
     "angular": "~1.3.12",
-    "ngstorage": "~0.3.0"
+    "ngstorage": "~0.3.0",
+    "jsrsasign-latest-all-min": "https://raw.githubusercontent.com/kjur/jsrsasign/master/jsrsasign-latest-all-min.js"
   },
   "devDependencies": {
     "json3": "~3.2.4",

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "angular": "~1.3.12",
     "ngstorage": "~0.3.0",
-    "jsrsasign-latest-all-min": "https://raw.githubusercontent.com/kjur/jsrsasign/master/jsrsasign-latest-all-min.js"
+    "jsrsasign": "~5.0.5"
   },
   "devDependencies": {
     "json3": "~3.2.4",

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -1,4 +1,4 @@
-/* oauth-ng - v0.4.4 - 2015-12-10 */
+/* oauth-ng - v0.4.4 - 2015-12-12 */
 
 'use strict';
 
@@ -20,273 +20,217 @@ angular.module('oauth', [
 
 'use strict';
 
-var accessTokenService = angular.module('oauth.idToken', []);
+var idTokenService = angular.module('oauth.idToken', []);
 
-accessTokenService.factory('IdToken', ['Storage', function(Storage){
+idTokenService.factory('IdToken', ['Storage', function(Storage){
 
-    var service = {
-      issuer: null,
-      clientId: null,
-      jwks: null
-    };
-    /**
-     * OidcException
-     * @param {string } message  - The exception error message
-     * @constructor
-     */
-    function OidcException(message) {
-      this.name = 'OidcException';
-      this.message = message;
+  var service = {
+    issuer: null,
+    clientId: null,
+    pubKey: null
+  };
+  /**
+   * OidcException
+   * @param {string } message  - The exception error message
+   * @constructor
+   */
+  function OidcException(message) {
+    this.name = 'OidcException';
+    this.message = message;
+  }
+  OidcException.prototype = new Error();
+  OidcException.prototype.constructor = OidcException;
+
+  /**
+   * For initialization
+   * @param scope
+   */
+  service.set = function(scope) {
+    this.issuer = scope.issuer;
+    this.clientId = scope.clientId;
+    this.pubKey = scope.pubKey;
+  };
+
+  /**
+   * Validates the id_token
+   * @param {String} idToken The id_token
+   * @returns {boolean} True if all the check passes, False otherwise
+   */
+  service.validateIdToken = function(idToken) {
+    return this.verifyIdTokenSig(idToken) && this.verifyIdTokenInfo(idToken);
+  };
+
+  /**
+   * Populate id token claims to map for future use
+   * @param idToken The id_token
+   * @param params  The target object for storing the claims
+   */
+  service.populateIdTokenClaims = function(idToken, params) {
+    params.id_token_claims = getIdTokenPayload(idToken);
+  };
+
+  /**
+   * Validate access_token based on the 'alg' and 'at_hash' value of the id_token header
+   * per spec: http://openid.net/specs/openid-connect-core-1_0.html#ImplicitTokenValidation
+   *
+   * @param idToken The id_token
+   * @param accessToken The access_token
+   * @returns {boolean} true if validation passes
+   */
+  service.validateAccessToken = function(idToken, accessToken) {
+    var header = getJsonObject(getIdTokenParts(idToken)[0]);
+    if (header.at_hash) {
+      var shalevel = header.alg.substr(2);
+      if (shalevel !== '256' && shalevel !== '384' && shalevel !== '512') {
+        throw new OidcException('Unsupported hash algorithm, expecting sha256, sha384, or sha512');
+      }
+      var md = new KJUR.crypto.MessageDigest({'alg':'sha'+ shalevel, 'prov':'cryptojs'});
+      //hex representation of the hash
+      var hexStr = md.digestString(accessToken);
+      //take first 128bits and base64url encoding it
+      var expected = hextob64u(hexStr.substring(0, 32));
+
+      return expected === header.at_hash;
+    } else {
+      return true;
     }
-    OidcException.prototype = new Error();
-    OidcException.prototype.constructor = OidcException;
+  };
 
-    /**
-     * For initialization
-     * @param scope
-     */
-    service.set = function(scope) {
-      this.issuer = scope.issuer;
-      this.clientId = scope.clientId;
-      this.jwks = scope.jwks;
-    };
+  /**
+   * Verifies the ID Token signature using the specified public key
+   * The id_token header can optionally carry public key or the url to retrieve the public key
+   * Otherwise will use the public key configured using 'pubKey'
+   *
+   * Supports only RSA signatures ['RS256', 'RS384', 'RS512']
+   * @param {string}idToken      The ID Token string
+   * @returns {boolean}          Indicates whether the signature is valid or not
+   * @throws {OidcException}
+   */
+  service.verifyIdTokenSig = function (idToken) {
 
-    /**
-     * Validates the id_token
-     * @param {String} idToken The id_token
-     * @returns {boolean} True if all the check passes, False otherwise
-     */
-    service.validateIdToken = function(idToken) {
-      return this.verifyIdTokenSig(idToken) && this.verifyIdTokenInfo(idToken);
-    };
+    var idtParts = getIdTokenParts(idToken);
+    var header = getJsonObject(idtParts[0]);
 
-    /**
-     * Populate id token claims to map for future use
-     * @param idToken The id_token
-     * @param params  The target object for storing the claims
-     */
-    service.populateIdTokenClaims = function(idToken, params) {
-      params.id_token_claims = getIdTokenPayload(idToken);
-    };
+    if(!header.alg || header.alg.substr(0, 2) !== 'RS') {
+      throw new OidcException('Unsupported JWS signature algorithm ' + header.alg);
+    }
 
-    /**
-     * Validate access_token based on the 'alg' and 'at_hash' value of the id_token header
-     * per spec: http://openid.net/specs/openid-connect-core-1_0.html#ImplicitTokenValidation
-     *
-     * @param idToken The id_token
-     * @param accessToken The access_token
-     * @returns {boolean} true if validation passes
-     */
-    service.validateAccessToken = function(idToken, accessToken) {
-      var header = getJsonObject(getIdTokenParts(idToken)[0]);
-      if (header.at_hash) {
-        var shalevel = header.alg.substr(2);
-        if (shalevel !== '256' && shalevel !== '384' && shalevel !== '512') {
-          throw new OidcException('Unsupported hash algorithm, expecting sha256, sha384, or sha512');
-        }
-        var md = new KJUR.crypto.MessageDigest({'alg':'sha'+ shalevel, 'prov':'cryptojs'});
-        //hex representation of the hash
-        var hexStr = md.digestString(accessToken);
-        //take first 128bits and base64url encoding it
-        var expected = hextob64u(hexStr.substring(0, 32));
+    var matchedPubKey = null;
 
-        return expected === header.at_hash;
-      } else {
-        return true;
+    if (header.jwk) {
+      //Take the JWK if it comes with the id_token
+      matchedPubKey = header.jwk;
+      if (matchedPubKey.kid && header.kid && matchedPubKey.kid !== header.kid) {
+        throw new OidcException('Json Wek Key ID not match');
       }
-    };
-
-    /**
-     * Verifies the ID Token signature using the JWK Keyset from jwks
-     * Supports only RSA signatures ['RS256', 'RS384', 'RS512']
-     * @param {string}idtoken      The ID Token string
-     * @returns {boolean}          Indicates whether the signature is valid or not
-     * @throws {OidcException}
-     */
-    service.verifyIdTokenSig = function (idtoken) {
-      var verified = false;
-
-      if(!this.jwks) {
-        throw new OidcException('jwks(Json Web Keys) parameter not set');
+      //TODO: Support for "jku" (JWK Set URL), "x5u" (X.509 URL), "x5c" (X.509 Certificate Chain) parameter to get key
+    } else {
+      //Use configured public key
+      matchedPubKey = this.pubKey;
+      if (typeof matchedPubKey !== 'string') {
+        throw new OidcException('Unsupported public key format, expecting PEM format');
       }
+    }
 
+    if(!matchedPubKey) {
+      throw new OidcException('No public key found to verify signature');
+    }
+
+    return rsaVerifyJWS(idToken, matchedPubKey, header.alg);
+  };
+
+  /**
+   * Validates the information in the ID Token against configuration
+   * @param {string} idtoken      The ID Token string
+   * @returns {boolean}           Validity of the ID Token
+   * @throws {OidcException}
+   */
+  service.verifyIdTokenInfo = function(idtoken) {
+    var valid = false;
+
+    if(idtoken) {
       var idtParts = getIdTokenParts(idtoken);
-      var header = getJsonObject(idtParts[0]);
-      var jwks = null;
+      var payload = getJsonObject(idtParts[1]);
+      if(payload) {
+        var now =  new Date() / 1000;
+        if( payload['iat'] >  now )
+          throw new OidcException('ID Token issued time is later than current time');
 
-      if(typeof this.jwks === 'string')
-        jwks = getJsonObject(this.jwks);
-      else if(typeof this.jwks === 'object')
-        jwks = this.jwks;
+        if(payload['exp'] < now )
+          throw new OidcException('ID Token expired');
 
-      if(header.alg && header.alg.substr(0, 2) == 'RS') {
-        var matchedPubKey = null;
-        if (jwks.keys) {
-          if (jwks.keys.length == 1) {
-            matchedPubKey = jwks.keys[0];
-          } else {
-            matchedPubKey = getMatchedKey(jwks.keys, 'RSA', 'sig', header.kid);
-          }
+        var audience = null;
+        if(payload['aud']) {
+          if(payload['aud'] instanceof Array) {
+            audience = payload['aud'][0];
+          } else
+            audience = payload['aud'];
         }
-        if (!matchedPubKey) {
-          throw new OidcException('No matching JWK found');
-        } else {
-          verified = rsaVerifyJWS(idtoken, matchedPubKey, header.alg);
-        }
+        if(audience && audience != this.clientId)
+          throw new OidcException('invalid audience');
+
+        if(payload['iss'] != this.issuer)
+          throw new OidcException('invalid issuer ' + payload['iss'] + ' != ' + this.issuer);
+
+        //TODO: nonce support ? probably need to redo current nonce support
+        //if(payload['nonce'] != sessionStorage['nonce'])
+        //  throw new OidcException('invalid nonce');
+        valid = true;
       } else
-        throw new OidcException('Unsupported JWS signature algorithm ' + header.alg);
+        throw new OidcException('Unable to parse JWS payload');
+    }
+    return valid;
+  };
 
-      return verified;
-    };
+  /**
+   * Verifies the JWS string using the JWK
+   * @param {string} jws      The JWS string
+   * @param {object} pubKey   The public key that will be used to verify the signature
+   * @param {string} alg      The algorithm string. Expecting 'RS256', 'RS384', or 'RS512'
+   * @returns {boolean}       Validity of the JWS signature
+   * @throws {OidcException}
+   */
+  var rsaVerifyJWS = function (jws, pubKey, alg) {
+    var rsaKey = KEYUTIL.getKey(pubKey);
+    return KJUR.jws.JWS.verify(jws, rsaKey, [alg]);
+  };
 
-    /**
-     * Validates the information in the ID Token against configuration
-     * @param {string} idtoken      The ID Token string
-     * @returns {boolean}           Validity of the ID Token
-     * @throws {OidcException}
-     */
-    service.verifyIdTokenInfo = function(idtoken) {
-      var valid = false;
+  /**
+   * Splits the ID Token string into the individual JWS parts
+   * @param  {string} id_token  ID Token
+   * @returns {Array} An array of the JWS compact serialization components (header, payload, signature)
+   */
+  var getIdTokenParts = function (id_token) {
+    var jws = new KJUR.jws.JWS();
+    jws.parseJWS(id_token);
+    return [jws.parsedJWS.headS, jws.parsedJWS.payloadS, jws.parsedJWS.si];
+  };
 
-      if(idtoken) {
-        var idtParts = getIdTokenParts(idtoken);
-        var payload = getJsonObject(idtParts[1]);
-        if(payload) {
-          var now =  new Date() / 1000;
-          if( payload['iat'] >  now )
-            throw new OidcException('ID Token issued time is later than current time');
+  /**
+   * Get the contents of the ID Token payload as an JSON object
+   * @param {string} id_token     ID Token
+   * @returns {object}            The ID Token payload JSON object
+   */
+  var getIdTokenPayload = function (id_token) {
+    var parts = getIdTokenParts(id_token);
+    if(parts)
+      return getJsonObject(parts[1]);
+  };
 
-          if(payload['exp'] < now )
-            throw new OidcException('ID Token expired');
+  /**
+   * Get the JSON object from the JSON string
+   * @param {string} jsonS    JSON string
+   * @returns {object|null}   JSON object or null
+   */
+  var getJsonObject = function (jsonS) {
+    var jws = KJUR.jws.JWS;
+    if(jws.isSafeJSONString(jsonS)) {
+      return jws.readSafeJSONString(jsonS);
+    }
+    return null;
+  };
 
-          var audience = null;
-          if(payload['aud']) {
-            if(payload['aud'] instanceof Array) {
-              audience = payload['aud'][0];
-            } else
-              audience = payload['aud'];
-          }
-          if(audience && audience != this.clientId)
-            throw new OidcException('invalid audience');
-
-          if(payload['iss'] != this.issuer)
-            throw new OidcException('invalid issuer ' + payload['iss'] + ' != ' + this.issuer);
-
-          //TODO: nonce support ? probably need to redo current nonce support
-          //if(payload['nonce'] != sessionStorage['nonce'])
-          //  throw new OidcException('invalid nonce');
-          valid = true;
-        } else
-          throw new OidcException('Unable to parse JWS payload');
-      }
-      return valid;
-    };
-
-    /**
-     * Verifies the JWS string using the JWK
-     * @param {string} jws      The JWS string
-     * @param {object} jwk      The JWK Key that will be used to verify the signature
-     * @param {string} alg      The algorithm string. Expecting 'RS256', 'RS384', or 'RS512'
-     * @returns {boolean}       Validity of the JWS signature
-     * @throws {OidcException}
-     */
-    var rsaVerifyJWS = function (jws, jwk, alg) {
-      if(jws && typeof jwk === 'object') {
-        console.log("verifying token with algorithm ["+alg+"]");
-        return KJUR.jws.JWS.verify(jws, jwk, [alg]);
-      }
-      return false;
-    };
-
-    /**
-     * Splits the ID Token string into the individual JWS parts
-     * @param  {string} id_token  ID Token
-     * @returns {Array} An array of the JWS compact serialization components (header, payload, signature)
-     */
-    var getIdTokenParts = function (id_token) {
-      var jws = new KJUR.jws.JWS();
-      jws.parseJWS(id_token);
-      return [jws.parsedJWS.headS, jws.parsedJWS.payloadS, jws.parsedJWS.si];
-    };
-
-    /**
-     * Get the contents of the ID Token payload as an JSON object
-     * @param {string} id_token     ID Token
-     * @returns {object}            The ID Token payload JSON object
-     */
-    var getIdTokenPayload = function (id_token) {
-      var parts = getIdTokenParts(id_token);
-      if(parts)
-        return getJsonObject(parts[1]);
-    };
-
-    /**
-     * Get the JSON object from the JSON string
-     * @param {string} jsonS    JSON string
-     * @returns {object|null}   JSON object or null
-     */
-    var getJsonObject = function (jsonS) {
-      var jws = KJUR.jws.JWS;
-      if(jws.isSafeJSONString(jsonS)) {
-        return jws.readSafeJSONString(jsonS);
-      }
-      return null;
-    };
-
-    /**
-     * Retrieve the JWK key that matches the input criteria
-     * @param {array} keys               JWK Keyset
-     * @param {string} kty               The 'kty' to match (RSA|EC). Only RSA is supported.
-     * @param {string} use               The 'use' to match (sig|enc).
-     * @param {string} kid               The 'kid' to match
-     * @returns {object} jwk             The matched JWK
-     */
-    var getMatchedKey = function (keys, kty, use, kid) {
-      var foundKeys = [];
-
-      if (typeof keys === 'object' && keys.length > 0) {
-        for (var i = 0; i < keys.length; i++) {
-          if (keys[i]['kty'] == kty)
-            foundKeys.push(keys[i]);
-        }
-
-        if (foundKeys.length == 0)
-          return null;
-
-        if (use) {
-          var temp = [];
-          for (var j = 0; j < foundKeys.length; j++) {
-            if (!foundKeys[j]['use'])
-              temp.push(foundKeys[j]);
-            else if (foundKeys[j]['use'] == use)
-              temp.push(foundKeys[j]);
-          }
-          foundKeys = temp;
-        }
-        if (foundKeys.length == 0)
-          return null;
-
-        if (kid) {
-          temp = [];
-          for (var k = 0; k < foundKeys.length; k++) {
-            if (foundKeys[k]['kid'] == kid)
-              temp.push(foundKeys[k]);
-          }
-          foundKeys = temp;
-        }
-        if (foundKeys.length == 0)
-          return null;
-        else
-          return foundKeys[0];
-      } else {
-        return null;
-      }
-
-    };
-
-
-
-    return service;
+  return service;
 
 }]);
 
@@ -734,7 +678,8 @@ directives.directive('oauth', [
         nonce: '@',          // (optional) Send nonce on auth request
                              // OIDC(OpenID Connect) extras:
         issuer: '@',         // (required for OpenID Connect) issuer of the id_token, should match the 'iss' claim in id_token payload
-        jwks: '@'            // (required for OpenID Connect) json web key(s), it will be used to verify the id_token signature
+        pubKey: '@'          // (optional for OpenID Connect) the public key(RSA public key or X509 certificate in PEM format) to verify the signature
+                             // If not set, the id_token header should carry information of the key or where to find the key
       }
     };
 

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -197,10 +197,10 @@ idTokenService.factory('IdToken', ['Storage', function(Storage) {
         if (now < payload.ntb)
           throw new OidcException('ID Token is invalid before '+ payload.ntb);
 
-        if (payload.iss && this.issuer && payload.iss != this.issuer)
+        if (payload.iss && this.issuer && payload.iss !== this.issuer)
           throw new OidcException('Invalid issuer ' + payload.iss + ' != ' + this.issuer);
 
-        if (payload.sub && this.subject && payload.sub != this.subject)
+        if (payload.sub && this.subject && payload.sub !== this.subject)
           throw new OidcException('Invalid subject ' + payload.sub + ' != ' + this.subject);
 
         if (payload.aud) {

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -1,4 +1,4 @@
-/* oauth-ng - v0.4.4 - 2015-12-06 */
+/* oauth-ng - v0.4.4 - 2015-12-10 */
 
 'use strict';
 
@@ -67,6 +67,33 @@ accessTokenService.factory('IdToken', ['Storage', function(Storage){
      */
     service.populateIdTokenClaims = function(idToken, params) {
       params.id_token_claims = getIdTokenPayload(idToken);
+    };
+
+    /**
+     * Validate access_token based on the 'alg' and 'at_hash' value of the id_token header
+     * per spec: http://openid.net/specs/openid-connect-core-1_0.html#ImplicitTokenValidation
+     *
+     * @param idToken The id_token
+     * @param accessToken The access_token
+     * @returns {boolean} true if validation passes
+     */
+    service.validateAccessToken = function(idToken, accessToken) {
+      var header = getJsonObject(getIdTokenParts(idToken)[0]);
+      if (header.at_hash) {
+        var shalevel = header.alg.substr(2);
+        if (shalevel !== '256' && shalevel !== '384' && shalevel !== '512') {
+          throw new OidcException('Unsupported hash algorithm, expecting sha256, sha384, or sha512');
+        }
+        var md = new KJUR.crypto.MessageDigest({'alg':'sha'+ shalevel, 'prov':'cryptojs'});
+        //hex representation of the hash
+        var hexStr = md.digestString(accessToken);
+        //take first 128bits and base64url encoding it
+        var expected = hextob64u(hexStr.substring(0, 32));
+
+        return expected === header.at_hash;
+      } else {
+        return true;
+      }
     };
 
     /**
@@ -382,15 +409,28 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
     }
 
     // OpenID Connect
-    if (params.id_token) {
+    if (params.id_token && !params.error) {
+      var valid = false;
+      var message = '';
       try {
-        if (IdToken.validateIdToken(params.id_token)) {
-          IdToken.populateIdTokenClaims(params.id_token, params);
-        } else {
-          params.error = 'Failed to validate id_token';
+        valid = IdToken.validateIdToken(params.id_token);
+        /*
+          if response_type is 'id_token token', then we will get both id_token and access_token
+          access_token needs to be validated as well
+         */
+        if (valid && params.access_token) {
+          valid = IdToken.validateAccessToken(params.id_token, params.access_token);
         }
       } catch (error) {
-        params.error = 'Failed to validate id_token: ' + error.message;
+        message = error.message;
+      }
+
+      if (valid) {
+        IdToken.populateIdTokenClaims(params.id_token, params);
+      } else {
+        params.id_token = null;
+        params.access_token = null;
+        params.error = 'Failed to validate token:' + message;
       }
       return params;
     }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
       'app/bower_components/angular-mocks/angular-mocks.js',
       'app/bower_components/ngstorage/ngStorage.js',
       'app/bower_components/timecop/timecop-0.1.1.js',
-      'app/bower_components/jsrsasign-latest-all-min/index.js',
+      'app/bower_components/jsrsasign/jsrsasign-latest-all-min.js',
       'app/scripts/*.js',
       'app/scripts/**/*.js',
       'app/views/**/*.html',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = function(config) {
       'app/bower_components/angular-mocks/angular-mocks.js',
       'app/bower_components/ngstorage/ngStorage.js',
       'app/bower_components/timecop/timecop-0.1.1.js',
+      'app/bower_components/jsrsasign-latest-all-min/index.js',
       'app/scripts/*.js',
       'app/scripts/**/*.js',
       'app/views/**/*.html',

--- a/test/spec/services/access-token.js
+++ b/test/spec/services/access-token.js
@@ -7,6 +7,8 @@ describe('AccessToken', function() {
   var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path&extra=stuff';
   var fragmentForever = 'access_token=token&token_type=bearer&state=/path&extra=stuff';
   var fragmentImmediate = 'access_token=token&token_type=bearer&expires_in=0&state=/path&extra=stuff';
+  var fragmentWithIdToken = 'access_token=token&token_type=bearer'+
+      '&id_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ&expires_in=3600';
   var denied   = 'error=access_denied&error_description=error';
   var expires_at = '2014-08-17T17:38:37.584Z';
   var token    = { access_token: 'token', token_type: 'bearer', expires_in: 7200, state: '/path', expires_at: expires_at };
@@ -136,6 +138,71 @@ describe('AccessToken', function() {
         expect(result.error).toBe('access_denied');
       });
     });
+
+    describe('with id token and access token in the fragment', function() {
+      beforeEach(function() {
+        $location.hash(fragmentWithIdToken);
+      });
+
+      describe('when all validation passes', function() {
+        beforeEach(function() {
+          //specific validation mechanism are tested in id-token spec
+          spyOn(IdToken, 'validateIdToken').and.returnValue(true);
+          spyOn(IdToken, 'validateAccessToken').and.returnValue(true);
+          result = AccessToken.set();
+        });
+
+        it('sets the access token', function() {
+          expect(result.access_token).toEqual('token');
+        });
+
+        it('sets the id token', function() {
+          expect(result.id_token).toEqual('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ');
+        });
+
+        it('populates id token claims', function() {
+          expect(result.id_token_claims).toBeDefined();
+          expect(result.id_token_claims.name).toEqual('John Doe');
+        });
+      });
+
+      describe('when id token validation fails', function(){
+        beforeEach(function() {
+          //specific validation mechanism are tested in id-token spec
+          spyOn(IdToken, 'validateIdToken').and.returnValue(false);
+          spyOn(IdToken, 'validateAccessToken').and.returnValue(true);
+          result = AccessToken.set();
+        });
+
+        it('erases access token and id token', function() {
+          expect(result.access_token).toEqual(null);
+          expect(result.id_token).toEqual(null);
+        });
+
+        it('sets the error', function() {
+          expect(result.error).toEqual('Failed to validate token:');
+        })
+      });
+
+      describe('when access token validation fails', function(){
+        beforeEach(function() {
+          //specific validation mechanism are tested in id-token spec
+          spyOn(IdToken, 'validateIdToken').and.returnValue(true);
+          spyOn(IdToken, 'validateAccessToken').and.returnValue(false);
+          result = AccessToken.set();
+        });
+
+        it('erases access token and id token', function() {
+          expect(result.access_token).toEqual(null);
+          expect(result.id_token).toEqual(null);
+        });
+
+        it('sets the error', function() {
+          expect(result.error).toEqual('Failed to validate token:');
+        })
+      });
+
+    })
   });
 
 

--- a/test/spec/services/access-token.js
+++ b/test/spec/services/access-token.js
@@ -2,7 +2,7 @@
 
 describe('AccessToken', function() {
 
-  var result, $location, Storage, AccessToken, date;
+  var result, $location, Storage, IdToken, AccessToken, date;
 
   var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path&extra=stuff';
   var fragmentForever = 'access_token=token&token_type=bearer&state=/path&extra=stuff';
@@ -15,6 +15,7 @@ describe('AccessToken', function() {
 
   beforeEach(inject(function($injector) { $location = $injector.get('$location'); }));
   beforeEach(inject(function($injector) { Storage = $injector.get('Storage'); }));
+  beforeEach(inject(function($injector) { IdToken = $injector.get('IdToken'); }));
   beforeEach(inject(function($injector) { AccessToken = $injector.get('AccessToken'); }));
 
 

--- a/test/spec/services/id-token.js
+++ b/test/spec/services/id-token.js
@@ -2,7 +2,7 @@ describe('IdToken', function() {
 
   var Storage, IdToken;
 
-  var publicKeyString, jwk;
+  var publicKeyString;
   var validIdToken, invalidIdToken;
   var validAccessToken;
 
@@ -30,9 +30,6 @@ describe('IdToken', function() {
         + "f0YN3/Q0auBkdbDR/ES2PbgKTJdkjc/rEeM0TxvOUf7HuUNOhrtAVEN1D5uuxE1W\n"
         + "SwIDAQAB"
         + "-----END PUBLIC KEY-----\n";
-
-    jwk = KEYUTIL.getKey(publicKeyString);
-
   });
 
   describe('validate an id_token with both signature and claims', function() {

--- a/test/spec/services/id-token.js
+++ b/test/spec/services/id-token.js
@@ -60,7 +60,7 @@ describe('IdToken', function() {
       IdToken.set({
         issuer: 'oidc',
         clientId: 'oauth-ng-client',
-        jwks: {keys: [jwk]}
+        pubKey: publicKeyString
       });
     });
 
@@ -84,7 +84,7 @@ describe('IdToken', function() {
         IdToken.set({
           issuer: 'oidc-rs-256',
           clientId: 'oauth-ng-client',
-          jwks: {keys: [jwk]}
+          pubKey: publicKeyString
         });
       });
 
@@ -105,7 +105,7 @@ describe('IdToken', function() {
         IdToken.set({
           issuer: 'oidc-rs-384',
           clientId: 'oauth-ng-client',
-          jwks: {keys: [jwk]}
+          pubKey: publicKeyString
         });
 
       });
@@ -127,7 +127,7 @@ describe('IdToken', function() {
         IdToken.set({
           issuer: 'oidc-rs-512',
           clientId: 'oauth-ng-client',
-          jwks: {keys: [jwk]}
+          pubKey: publicKeyString
         });
 
       });
@@ -173,7 +173,7 @@ describe('IdToken', function() {
         IdToken.set({
           issuer: 'oidc',
           clientId: 'oauth-ng-client',
-          jwks: {keys: [jwk]}
+          pubKey: publicKeyString
         });
       });
 
@@ -194,7 +194,7 @@ describe('IdToken', function() {
         IdToken.set({
           issuer: 'oidc',
           clientId: 'oauth-ng-client',
-          jwks: {keys: [jwk]}
+          pubKey: publicKeyString
         });
       });
 
@@ -215,7 +215,7 @@ describe('IdToken', function() {
         IdToken.set({
           issuer: 'oidc',
           clientId: 'oauth-ng-client',
-          jwks: {keys: [jwk]}
+          pubKey: publicKeyString
         });
       });
 

--- a/test/spec/services/id-token.js
+++ b/test/spec/services/id-token.js
@@ -1,0 +1,72 @@
+describe('AccessToken', function() {
+
+  var $location, Storage, IdToken;
+
+  var publicKeyString;
+  var valid_id_token, expired_id_token;
+
+  beforeEach(module('oauth'));
+
+  beforeEach(inject(function ($injector) {
+    $location = $injector.get('$location');
+  }));
+  beforeEach(inject(function ($injector) {
+    Storage = $injector.get('Storage');
+  }));
+  beforeEach(inject(function ($injector) {
+    IdToken = $injector.get('IdToken');
+  }));
+
+  describe('IdToken service', function () {
+
+    describe('validate', function () {
+
+      beforeEach(function () {
+
+        /**
+         * http://kjur.github.io/jsjws/tool_jwt.html generated sample id_token, signed by RS256 with default private key
+         * The public key is shown as below
+         */
+        publicKeyString =
+          "-----BEGIN PUBLIC KEY-----\n"
+        + "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA33TqqLR3eeUmDtHS89qF\n"
+        + "3p4MP7Wfqt2Zjj3lZjLjjCGDvwr9cJNlNDiuKboODgUiT4ZdPWbOiMAfDcDzlOxA\n"
+        + "04DDnEFGAf+kDQiNSe2ZtqC7bnIc8+KSG/qOGQIVaay4Ucr6ovDkykO5Hxn7OU7s\n"
+        + "Jp9TP9H0JH8zMQA6YzijYH9LsupTerrY3U6zyihVEDXXOv08vBHk50BMFJbE9iwF\n"
+        + "wnxCsU5+UZUZYw87Uu0n4LPFS9BT8tUIvAfnRXIEWCha3KbFWmdZQZlyrFw0buUE\n"
+        + "f0YN3/Q0auBkdbDR/ES2PbgKTJdkjc/rEeM0TxvOUf7HuUNOhrtAVEN1D5uuxE1W\n"
+        + "SwIDAQAB"
+        + "-----END PUBLIC KEY-----\n";
+
+        //Valid token, expires at 20251231235959Z UTC
+        valid_id_token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9' +
+            '.eyJpc3MiOiJvaWRjIiwic3ViIjoib2F1dGgtbmctY2xpZW50IiwibmJmIjoxNDQ5MjY3Mzg1LCJleHAiOjE3NjcyMjU1OTksImlhdCI6MTQ0OTI2NzM4NSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUuY29tL3JlZ2lzdGVyIn0' +
+            '.MXBbWkr1Sf6KRn11IgEXyVg5g5VVUOSyLhTglgL8fI13aGf6SquVy0ZNn7ajTym5a_fJHPWLlgpvo-v98xuMBC9cLH_NN3ocrZAQkkW19G4AVY-LsOURp0t9JzVEb-pEe8Zps8O7Mumj0qSlr-4Dnyb3UMqdwZTcSgUTrbdyf6Qa7KHA0myANLDs2T8ctlSEptgVHPj8Zy9tk9UUlDZgsU4KoEpanDt7c1GzQJu7KEI3iJYlVEwDgMqu0EWn64aaP-w1OKZAyHbJWdMwun7i9edLonQ37M67Mb8ox6-cx8fxS3s3h6b3jRS5L0RACFVtB9lF4f_0yPVBwcTBhzYBOg';
+
+        //Expired token
+        expired_id_token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9' +
+            '.eyJpc3MiOiJvaWRjIiwic3ViIjoib2F1dGgtbmctY2xpZW50IiwibmJmIjoxNDQ5MjE1OTMxLCJleHAiOjE0NDkyMTk1MzEsImlhdCI6MTQ0OTIxNTkzMSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUuY29tL3JlZ2lzdGVyIn0' +
+            '.jlmI1b7LYGFRPTLdBcBTgVKwSabwKwsuqQpZAAvX7xF7Xf32miAA_FG-jJegTkjJdjImdNmRqDrR1iu2yX-785nbhNm_eOUChTkWplqszE6-lOvoJy5q8jXlWnS4f6q7EM890eVO2prtLmFW6zUO6xIa4cVFzrWSSN7VjPYV09F38DYGfymE3HmwdNyu56CBuTaYv1SW0wUavtu4_FCt50gfOGQ9tVkDHSNXj8xviskiOJ9TbHAesGPgPMHqCfAR0fRQf3lK0pxd76BEw3f2zYCnsPu_JFDiwiK8MBzHMpmP4i9kxl18mElA4CylwXKDCaGY5Fef3gS9p5mWV46V0A';
+
+
+        var jwk  = KEYUTIL.getKey(publicKeyString);
+        console.log("------------");
+        console.log(jwk);
+
+        IdToken.set({
+          issuer: 'oidc',
+          clientId: 'oauth-ng-client',
+          jwks: {keys: [jwk]}
+        });
+      });
+
+      it('validate token successfully', function () {
+        expect(IdToken.validateIdToken(valid_id_token)).toEqual(true);
+      });
+
+    });
+
+
+  });
+
+});

--- a/test/spec/services/id-token.js
+++ b/test/spec/services/id-token.js
@@ -1,15 +1,12 @@
 describe('AccessToken', function() {
 
-  var $location, Storage, IdToken;
+  var Storage, IdToken;
 
   var publicKeyString;
   var valid_id_token, expired_id_token;
 
   beforeEach(module('oauth'));
 
-  beforeEach(inject(function ($injector) {
-    $location = $injector.get('$location');
-  }));
   beforeEach(inject(function ($injector) {
     Storage = $injector.get('Storage');
   }));
@@ -50,8 +47,6 @@ describe('AccessToken', function() {
 
 
         var jwk  = KEYUTIL.getKey(publicKeyString);
-        console.log("------------");
-        console.log(jwk);
 
         IdToken.set({
           issuer: 'oidc',

--- a/test/spec/services/id-token.js
+++ b/test/spec/services/id-token.js
@@ -1,8 +1,8 @@
-describe('AccessToken', function() {
+describe('IdToken', function() {
 
   var Storage, IdToken;
 
-  var publicKeyString;
+  var publicKeyString, jwk;
   var valid_id_token, expired_id_token;
 
   beforeEach(module('oauth'));
@@ -14,28 +14,32 @@ describe('AccessToken', function() {
     IdToken = $injector.get('IdToken');
   }));
 
-  describe('IdToken service', function () {
+  describe('validate id_token with algorithm', function () {
+    beforeEach(function () {
+      /**
+       * http://kjur.github.io/jsjws/tool_jwt.html generated sample id_token, signed by default private key
+       * The public key is shown as below
+       */
+      publicKeyString =
+          "-----BEGIN PUBLIC KEY-----\n"
+          + "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA33TqqLR3eeUmDtHS89qF\n"
+          + "3p4MP7Wfqt2Zjj3lZjLjjCGDvwr9cJNlNDiuKboODgUiT4ZdPWbOiMAfDcDzlOxA\n"
+          + "04DDnEFGAf+kDQiNSe2ZtqC7bnIc8+KSG/qOGQIVaay4Ucr6ovDkykO5Hxn7OU7s\n"
+          + "Jp9TP9H0JH8zMQA6YzijYH9LsupTerrY3U6zyihVEDXXOv08vBHk50BMFJbE9iwF\n"
+          + "wnxCsU5+UZUZYw87Uu0n4LPFS9BT8tUIvAfnRXIEWCha3KbFWmdZQZlyrFw0buUE\n"
+          + "f0YN3/Q0auBkdbDR/ES2PbgKTJdkjc/rEeM0TxvOUf7HuUNOhrtAVEN1D5uuxE1W\n"
+          + "SwIDAQAB"
+          + "-----END PUBLIC KEY-----\n";
 
-    describe('validate', function () {
+      jwk = KEYUTIL.getKey(publicKeyString);
+    });
+
+
+    describe('RS256', function () {
 
       beforeEach(function () {
 
-        /**
-         * http://kjur.github.io/jsjws/tool_jwt.html generated sample id_token, signed by RS256 with default private key
-         * The public key is shown as below
-         */
-        publicKeyString =
-          "-----BEGIN PUBLIC KEY-----\n"
-        + "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA33TqqLR3eeUmDtHS89qF\n"
-        + "3p4MP7Wfqt2Zjj3lZjLjjCGDvwr9cJNlNDiuKboODgUiT4ZdPWbOiMAfDcDzlOxA\n"
-        + "04DDnEFGAf+kDQiNSe2ZtqC7bnIc8+KSG/qOGQIVaay4Ucr6ovDkykO5Hxn7OU7s\n"
-        + "Jp9TP9H0JH8zMQA6YzijYH9LsupTerrY3U6zyihVEDXXOv08vBHk50BMFJbE9iwF\n"
-        + "wnxCsU5+UZUZYw87Uu0n4LPFS9BT8tUIvAfnRXIEWCha3KbFWmdZQZlyrFw0buUE\n"
-        + "f0YN3/Q0auBkdbDR/ES2PbgKTJdkjc/rEeM0TxvOUf7HuUNOhrtAVEN1D5uuxE1W\n"
-        + "SwIDAQAB"
-        + "-----END PUBLIC KEY-----\n";
-
-        //Valid token, expires at 20251231235959Z UTC
+        //Valid token with RS256, expires at 20251231235959Z UTC
         valid_id_token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9' +
             '.eyJpc3MiOiJvaWRjIiwic3ViIjoib2F1dGgtbmctY2xpZW50IiwibmJmIjoxNDQ5MjY3Mzg1LCJleHAiOjE3NjcyMjU1OTksImlhdCI6MTQ0OTI2NzM4NSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUuY29tL3JlZ2lzdGVyIn0' +
             '.MXBbWkr1Sf6KRn11IgEXyVg5g5VVUOSyLhTglgL8fI13aGf6SquVy0ZNn7ajTym5a_fJHPWLlgpvo-v98xuMBC9cLH_NN3ocrZAQkkW19G4AVY-LsOURp0t9JzVEb-pEe8Zps8O7Mumj0qSlr-4Dnyb3UMqdwZTcSgUTrbdyf6Qa7KHA0myANLDs2T8ctlSEptgVHPj8Zy9tk9UUlDZgsU4KoEpanDt7c1GzQJu7KEI3iJYlVEwDgMqu0EWn64aaP-w1OKZAyHbJWdMwun7i9edLonQ37M67Mb8ox6-cx8fxS3s3h6b3jRS5L0RACFVtB9lF4f_0yPVBwcTBhzYBOg';
@@ -44,9 +48,6 @@ describe('AccessToken', function() {
         expired_id_token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9' +
             '.eyJpc3MiOiJvaWRjIiwic3ViIjoib2F1dGgtbmctY2xpZW50IiwibmJmIjoxNDQ5MjE1OTMxLCJleHAiOjE0NDkyMTk1MzEsImlhdCI6MTQ0OTIxNTkzMSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUuY29tL3JlZ2lzdGVyIn0' +
             '.jlmI1b7LYGFRPTLdBcBTgVKwSabwKwsuqQpZAAvX7xF7Xf32miAA_FG-jJegTkjJdjImdNmRqDrR1iu2yX-785nbhNm_eOUChTkWplqszE6-lOvoJy5q8jXlWnS4f6q7EM890eVO2prtLmFW6zUO6xIa4cVFzrWSSN7VjPYV09F38DYGfymE3HmwdNyu56CBuTaYv1SW0wUavtu4_FCt50gfOGQ9tVkDHSNXj8xviskiOJ9TbHAesGPgPMHqCfAR0fRQf3lK0pxd76BEw3f2zYCnsPu_JFDiwiK8MBzHMpmP4i9kxl18mElA4CylwXKDCaGY5Fef3gS9p5mWV46V0A';
-
-
-        var jwk  = KEYUTIL.getKey(publicKeyString);
 
         IdToken.set({
           issuer: 'oidc',
@@ -61,7 +62,52 @@ describe('AccessToken', function() {
 
     });
 
+    describe('RS384', function () {
+
+      beforeEach(function() {
+        //Valid token with RS384, expires at 20251231235959Z UTC
+        valid_id_token = 'eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9' +
+            '.eyJpc3MiOiJvaWRjLXJzLTM4NCIsInN1YiI6Im9hdXRoLW5nLWNsaWVudCIsIm5iZiI6MTQ0OTQ0NTM3NSwiZXhwIjoxNzY3MjI1NTk5LCJpYXQiOjE0NDk0NDUzNzUsImp0aSI6ImlkMTIzNDU2IiwidHlwIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9yZWdpc3RlciJ9' +
+            '.cDSfORFIZ28nUgvbdJ0wwe-JtZOy5J40--xYfJBPbwRJz02EscFlRD-xNqRB9eEsVVK4shW9AtF4yfp3Sa_jcjziGlQNwpRzFhnCqrADupMNNhK-z1SmuxgG_zfP7plXVAhg1IJ671w43I2PmXQw5wAKpAMwun4J-mxHP7ZV6__z_hxv4QclONHrk23_ebHJXi8W4q7B7n-amQQZ-kKQf8OblZIX9kAF58WIhyA5ZNqXGZ_hmcDKUVlBpgiurpD8u429NwrlauowHCQI_zMKlaEzJvH5qNhXLNbFgLmhrQFYo_VW48ZjHygmAkuuKt0jioR0dUeYirTGq-xEBcOpnw';
+
+        IdToken.set({
+          issuer: 'oidc-rs-384',
+          clientId: 'oauth-ng-client',
+          jwks: {keys: [jwk]}
+        });
+
+      });
+
+      it('validate token successfully', function () {
+        expect(IdToken.validateIdToken(valid_id_token)).toEqual(true);
+      });
+
+    });
+
+    describe('RS512', function () {
+
+      beforeEach(function() {
+        //Valid token with RS512, expires at 20251231235959Z UTC
+        valid_id_token = 'eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9' +
+            '.eyJpc3MiOiJvaWRjLXJzLTUxMiIsInN1YiI6Im9hdXRoLW5nLWNsaWVudCIsIm5iZiI6MTQ0OTQ0NzQyMiwiZXhwIjoxNzY3MjI1NTk5LCJpYXQiOjE0NDk0NDc0MjIsImp0aSI6ImlkMTIzNDU2IiwidHlwIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9yZWdpc3RlciJ9' +
+            '.BAqggV91_YwQmnKty-qHzi61WgUpLue7gFWDe72VzHzcQhYu1STLduBxtr3qtsl6XzVDL6N0AmYfpFwMQQ8dRMaLLsnx6wg7Mi9nqCkDTL1Px5biL9AM4C3S32N6iJ4nFyJgUiFJ4RWG9f-78k4PG51xvSCkA-2TbODU1KsXRnc3o9SrQKw8pWnjmxNIfDtfzkxEdBlePWuknZGeaJBlR4hBRrxH1GnNDVW3aeuLJl4y1IOIbUxsnNW8HgAm6KpoCVAbPN7YzQPfDEIQgaNSS_i7Nkuq9Rno_6ivfqxs3QCiEqHJkAh8W2J3N8iPpRrCW03oQp2sGvmRTxxvxuxZbw'
+
+        IdToken.set({
+          issuer: 'oidc-rs-512',
+          clientId: 'oauth-ng-client',
+          jwks: {keys: [jwk]}
+        });
+
+      });
+
+      it('validate token successfully', function () {
+        expect(IdToken.validateIdToken(valid_id_token)).toEqual(true);
+      });
+
+    });
 
   });
+
+
 
 });

--- a/test/spec/services/id-token.js
+++ b/test/spec/services/id-token.js
@@ -3,7 +3,7 @@ describe('IdToken', function() {
   var Storage, IdToken;
 
   var publicKeyString, jwk;
-  var valid_id_token, invalidIdToken;
+  var validIdToken, invalidIdToken;
 
   beforeEach(module('oauth'));
 
@@ -37,7 +37,7 @@ describe('IdToken', function() {
   describe('validate an id_token with both signature and claims', function() {
     beforeEach(function () {
       //Valid token with RS256, expires at 20251231235959Z UTC
-      valid_id_token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9' +
+      validIdToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9' +
           '.eyJpc3MiOiJvaWRjIiwic3ViIjoib2F1dGgtbmctY2xpZW50IiwibmJmIjoxNDQ5MjY3Mzg1LCJleHAiOjE3NjcyMjU1OTksImlhdCI6MTQ0OTI2NzM4NSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUuY29tL3JlZ2lzdGVyIn0' +
           '.MXBbWkr1Sf6KRn11IgEXyVg5g5VVUOSyLhTglgL8fI13aGf6SquVy0ZNn7ajTym5a_fJHPWLlgpvo-v98xuMBC9cLH_NN3ocrZAQkkW19G4AVY-LsOURp0t9JzVEb-pEe8Zps8O7Mumj0qSlr-4Dnyb3UMqdwZTcSgUTrbdyf6Qa7KHA0myANLDs2T8ctlSEptgVHPj8Zy9tk9UUlDZgsU4KoEpanDt7c1GzQJu7KEI3iJYlVEwDgMqu0EWn64aaP-w1OKZAyHbJWdMwun7i9edLonQ37M67Mb8ox6-cx8fxS3s3h6b3jRS5L0RACFVtB9lF4f_0yPVBwcTBhzYBOg';
 
@@ -49,7 +49,7 @@ describe('IdToken', function() {
     });
 
     it('with success', function () {
-      expect(IdToken.validateIdToken(valid_id_token)).toEqual(true);
+      expect(IdToken.validateIdToken(validIdToken)).toEqual(true);
     });
 
   });
@@ -61,7 +61,7 @@ describe('IdToken', function() {
       beforeEach(function () {
 
         //Valid token with RS256, expires at 20251231235959Z UTC
-        valid_id_token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9' +
+        validIdToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9' +
             '.eyJpc3MiOiJvaWRjLXJzLTI1NiIsInN1YiI6Im9hdXRoLW5nLWNsaWVudCIsIm5iZiI6MTQ0OTQ0OTE0NCwiZXhwIjoxNzY3MjI1NTk5LCJpYXQiOjE0NDk0NDkxNDQsImp0aSI6ImlkMTIzNDU2IiwidHlwIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9yZWdpc3RlciJ9' +
             '.lpxeRY_IqsvgWLj6H2ghre8dBBtsSF-bnjWHtVvhQIuerztMQOX20CCqtVFGScIZcI4gHxtEZGauF-sX3zwaLuqPtzORjaBiH0vV6C-3ZyqZrCU_n-TozKAwpSYyyHQpJ-xKdGRaOdd7_4vDtaFBWyHLXp1hbYvMftkPCvGjO25GppGQ7MjxCnd7IAPn0obXx2lZr1q0hHT7532O5dlmsPHTyrTvrSupTOVH3CZe3ZghM6R_mlagyfRh1Pf2cdRQkXJ0gEHf4GYpBbz-E3YfCyxcvQRPzfKnpLGH16M1_jM0mc3z5zVsegi62NNr79B8hExG5OtXfDMvws4LDfps2A';
 
@@ -73,7 +73,7 @@ describe('IdToken', function() {
       });
 
       it('validate token successfully', function () {
-        expect(IdToken.verifyIdTokenSig(valid_id_token)).toEqual(true);
+        expect(IdToken.verifyIdTokenSig(validIdToken)).toEqual(true);
       });
 
     });
@@ -82,7 +82,7 @@ describe('IdToken', function() {
 
       beforeEach(function() {
         //Valid token with RS384, expires at 20251231235959Z UTC
-        valid_id_token = 'eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9' +
+        validIdToken = 'eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9' +
             '.eyJpc3MiOiJvaWRjLXJzLTM4NCIsInN1YiI6Im9hdXRoLW5nLWNsaWVudCIsIm5iZiI6MTQ0OTQ0NTM3NSwiZXhwIjoxNzY3MjI1NTk5LCJpYXQiOjE0NDk0NDUzNzUsImp0aSI6ImlkMTIzNDU2IiwidHlwIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9yZWdpc3RlciJ9' +
             '.cDSfORFIZ28nUgvbdJ0wwe-JtZOy5J40--xYfJBPbwRJz02EscFlRD-xNqRB9eEsVVK4shW9AtF4yfp3Sa_jcjziGlQNwpRzFhnCqrADupMNNhK-z1SmuxgG_zfP7plXVAhg1IJ671w43I2PmXQw5wAKpAMwun4J-mxHP7ZV6__z_hxv4QclONHrk23_ebHJXi8W4q7B7n-amQQZ-kKQf8OblZIX9kAF58WIhyA5ZNqXGZ_hmcDKUVlBpgiurpD8u429NwrlauowHCQI_zMKlaEzJvH5qNhXLNbFgLmhrQFYo_VW48ZjHygmAkuuKt0jioR0dUeYirTGq-xEBcOpnw';
 
@@ -95,7 +95,7 @@ describe('IdToken', function() {
       });
 
       it('validate token successfully', function () {
-        expect(IdToken.verifyIdTokenSig(valid_id_token)).toEqual(true);
+        expect(IdToken.verifyIdTokenSig(validIdToken)).toEqual(true);
       });
 
     });
@@ -104,7 +104,7 @@ describe('IdToken', function() {
 
       beforeEach(function() {
         //Valid token with RS512, expires at 20251231235959Z UTC
-        valid_id_token = 'eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9' +
+        validIdToken = 'eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9' +
             '.eyJpc3MiOiJvaWRjLXJzLTUxMiIsInN1YiI6Im9hdXRoLW5nLWNsaWVudCIsIm5iZiI6MTQ0OTQ0NzQyMiwiZXhwIjoxNzY3MjI1NTk5LCJpYXQiOjE0NDk0NDc0MjIsImp0aSI6ImlkMTIzNDU2IiwidHlwIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9yZWdpc3RlciJ9' +
             '.BAqggV91_YwQmnKty-qHzi61WgUpLue7gFWDe72VzHzcQhYu1STLduBxtr3qtsl6XzVDL6N0AmYfpFwMQQ8dRMaLLsnx6wg7Mi9nqCkDTL1Px5biL9AM4C3S32N6iJ4nFyJgUiFJ4RWG9f-78k4PG51xvSCkA-2TbODU1KsXRnc3o9SrQKw8pWnjmxNIfDtfzkxEdBlePWuknZGeaJBlR4hBRrxH1GnNDVW3aeuLJl4y1IOIbUxsnNW8HgAm6KpoCVAbPN7YzQPfDEIQgaNSS_i7Nkuq9Rno_6ivfqxs3QCiEqHJkAh8W2J3N8iPpRrCW03oQp2sGvmRTxxvxuxZbw'
 
@@ -117,7 +117,7 @@ describe('IdToken', function() {
       });
 
       it('validate token successfully', function () {
-        expect(IdToken.verifyIdTokenSig(valid_id_token)).toEqual(true);
+        expect(IdToken.verifyIdTokenSig(validIdToken)).toEqual(true);
       });
 
     });

--- a/test/spec/services/id-token.js
+++ b/test/spec/services/id-token.js
@@ -4,6 +4,7 @@ describe('IdToken', function() {
 
   var publicKeyString, jwk;
   var validIdToken, invalidIdToken;
+  var validAccessToken;
 
   beforeEach(module('oauth'));
 
@@ -36,7 +37,22 @@ describe('IdToken', function() {
 
   describe('validate an id_token with both signature and claims', function() {
     beforeEach(function () {
-      //Valid token with RS256, expires at 20251231235959Z UTC
+      /*
+        Valid token with RS256, expires at 20251231235959Z UTC
+        https://jwt.io has a debugger that can help view the id_token's header and payload
+
+        e.g. The header of following token is { "alg": "RS256", "typ": "JWT" }
+             The body of the following token is:
+             {
+               "iss": "oidc",
+               "sub": "oauth-ng-client",
+               "nbf": 1449267385,
+               "exp": 1767225599,
+               "iat": 1449267385,
+               "jti": "id123456",
+               "typ": "https://example.com/register"
+             }
+       */
       validIdToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9' +
           '.eyJpc3MiOiJvaWRjIiwic3ViIjoib2F1dGgtbmctY2xpZW50IiwibmJmIjoxNDQ5MjY3Mzg1LCJleHAiOjE3NjcyMjU1OTksImlhdCI6MTQ0OTI2NzM4NSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUuY29tL3JlZ2lzdGVyIn0' +
           '.MXBbWkr1Sf6KRn11IgEXyVg5g5VVUOSyLhTglgL8fI13aGf6SquVy0ZNn7ajTym5a_fJHPWLlgpvo-v98xuMBC9cLH_NN3ocrZAQkkW19G4AVY-LsOURp0t9JzVEb-pEe8Zps8O7Mumj0qSlr-4Dnyb3UMqdwZTcSgUTrbdyf6Qa7KHA0myANLDs2T8ctlSEptgVHPj8Zy9tk9UUlDZgsU4KoEpanDt7c1GzQJu7KEI3iJYlVEwDgMqu0EWn64aaP-w1OKZAyHbJWdMwun7i9edLonQ37M67Mb8ox6-cx8fxS3s3h6b3jRS5L0RACFVtB9lF4f_0yPVBwcTBhzYBOg';
@@ -124,6 +140,24 @@ describe('IdToken', function() {
 
   });
 
+
+  describe('validate access_token with id_token header information', function () {
+
+    beforeEach(function() {
+      /*
+       Sample id_token and access_token pair (corresponds to response_type = 'id_token token'
+       Get more examples at google playground: https://developers.google.com/oauthplayground/
+       */
+      validIdToken = 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjJhODc0MjBlY2YxNGU5MzRmOWY5MDRhMDE0NzY4MTMyMDNiMzk5NGIifQ' +
+          '.eyJpc3MiOiJhY2NvdW50cy5nb29nbGUuY29tIiwic3ViIjoiMTEwMTY5NDg0NDc0Mzg2Mjc2MzM0IiwiYXpwIjoiNDA3NDA4NzE4MTkyLmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29tIiwiYXRfaGFzaCI6ImFVQWtKRy11Nng0UlRXdUlMV3ktQ0EiLCJhdWQiOiI0MDc0MDg3MTgxOTIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJpYXQiOjE0MzIwODI4NzgsImV4cCI6MTQzMjA4NjQ3OH0' +
+          '.xSwhf4KvEztFFhVj4YdgKFOC8aPEoLAAZcXDWIh6YBXpfjzfnwYhaQgsmCofzOl53yirpbj5h7Om5570yzlUziP5TYNIqrA3Nyaj60-ZyXY2JMIBWYYMr3SRyhXdW0Dp71tZ5IaxMFlS8fc0MhSx55ZNrCV-3qmkTLeTTY1_4Jc';
+      validAccessToken = 'ya29.eQETFbFOkAs8nWHcmYXKwEi0Zz46NfsrUU_KuQLOLTwWS40y6Fb99aVzEXC0U14m61lcPMIr1hEIBA';
+    });
+
+    it('should succeed', function() {
+      expect(IdToken.validateAccessToken(validIdToken, validAccessToken)).toEqual(true);
+    })
+  });
 
 
   describe('detect false id_token with', function () {

--- a/test/spec/services/id-token.js
+++ b/test/spec/services/id-token.js
@@ -175,7 +175,7 @@ describe('IdToken', function() {
       });
 
       it('should throw exception', function () {
-        expect(function(){ IdToken.verifyIdTokenInfo(invalidIdToken) }).toThrowError(/invalid issuer/);
+        expect(function(){ IdToken.verifyIdTokenInfo(invalidIdToken) }).toThrowError(/Invalid issuer/);
       });
 
     });


### PR DESCRIPTION
OpenID Connect is built on top of OAuth2, This PR is trying to implement the Implicit Flow(Per http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth)

Flow wise there's actually not much change. The major changes (as opposed to regular OAuth2) are:
1. When sending auth request: `scope` is usually `openid`, and `response_type` is either `id_token` or `id_token token`. e.g.
```
GET /authorize?
    response_type=id_token%20token
    &client_id=s6BhdRkqt3
    &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
    &scope=openid%20profile
    &state=af0ifjsldkj
    &nonce=n-0S6_WzA2Mj HTTP/1.1
  Host: server.example.com
```
2.When getting successful auth response: Besides the other values that OAuth2 would have, it will have one more `id_token`, which is a JWT format token. e.g. 
```
HTTP/1.1 302 Found
  Location: https://client.example.org/cb#
    access_token=SlAV32hkKG
    &token_type=bearer
    &id_token=eyJ0 ... NiJ9.eyJ1c ... I6IjIifX0.DeWt4Qu ... ZXso
    &expires_in=3600
    &state=af0ifjsldkj
```

It definitely needs more documentation and automation test coverages(probably even more manual testings). 
@andreareginato @m00s  I'm just trying to see if you guys would be interested in such a feature, and hoping to get some comments / suggestions at the same time. 
